### PR TITLE
fix: remove unused imports in fake_nav2_server.py

### DIFF
--- a/src/devkit_bringup/resource/fake_nav2_server.py
+++ b/src/devkit_bringup/resource/fake_nav2_server.py
@@ -30,7 +30,7 @@ from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
 
-from geometry_msgs.msg import Pose, PoseStamped, Quaternion
+from geometry_msgs.msg import Pose, PoseStamped
 from nav2_msgs.action import (
     FollowWaypoints,
     NavigateThroughPoses,
@@ -42,7 +42,6 @@ from rosgraph_msgs.msg import Clock
 from topological_nav_simulator.virtual_robot import (
     VirtualRobot,
     _euler_from_quaternion,
-    _lerp,
     _quaternion_from_yaw,
     _slerp_yaw,
 )


### PR DESCRIPTION
## Summary
Removes two provably-unused imports in `src/devkit_bringup/resource/fake_nav2_server.py`, as reported in #66:

- `Quaternion` from `geometry_msgs.msg`
- `_lerp` from `topological_nav_simulator.virtual_robot`

Both names appear only on their import lines and are never referenced elsewhere in the file. All sibling imports are genuinely used and left untouched (`Pose`, `PoseStamped`, `_euler_from_quaternion`, `_quaternion_from_yaw`, `_slerp_yaw`, `VirtualRobot`).

## Type of change
Dead-code removal — no behavior change.

## Verification
- `ruff check ... --select F` (pyflakes) — all checks passed; no F401 unused-import findings remain.
- `python3 -m py_compile` — file compiles cleanly.

Scope is kept strictly to the dead-code removal the issue requested, per the repo's "stay focused on the requested task" guideline. A pre-existing `I001` import-sort note on this file was intentionally not touched to avoid unrelated churn.

Closes #66