### PR TITLE
fix: replace raw print() with logging in on_startup()

### DIFF
--- a/src/devkit_driver/devkit_driver/devkit_driver_node.py
+++ b/src/devkit_driver/devkit_driver/devkit_driver_node.py
@@ -3,6 +3,7 @@
 import threading
 from pathlib import Path
 import os
+import logging
 
 import rclpy
 from feldfreund_devkit import FeldfreundHardware, FeldfreundSimulation, System, api
@@ -74,13 +75,18 @@ def on_startup() -> None:
     # Priority 3: Relative path from script (host-side execution fallback)
     if not config_path.exists():
         config_path = Path(__file__).parents[3] / 'devkit_bringup/config/feldfreund.py'
+    
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    log = logging.getLogger("devkit_driver.startup")
+
 
     if not config_path.exists():
         # Node cannot safely initialize without a hardware definition
-        print(f"FATAL: Configuration file not found at {config_path}")
+        log.critical("Configuration file not found at %s", config_path)
         os._exit(1)
 
-    print(f"SYSTEM: Loading hardware configuration from {config_path}")
+    log.info("Loading hardware configuration from %s", config_path)
+
 
     config = config_from_file(str(config_path))
     system = System(config)


### PR DESCRIPTION
Fixes #67

## Changes
- Added `import logging` to imports
- Replaced raw `print()` calls in `on_startup()` with Python stdlib `logging`
- Configured `logging.basicConfig()` with INFO level and standard format
- Used `log.critical()` for the fatal config-not-found message
- Used `log.info()` for the config loading message

## Why
Raw `print()` calls in `on_startup()` can get buffered or dropped under
ros2 launch / systemd / Docker. Using the logging module ensures proper
log levels, timestamps, and consistent formatting.