### PR TITLE
Using Tmule to launch in tmux sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Use the management script to build the ROS 2 workspace and launch the robot stac
 xhost +local:docker
 ./manage.py 
 ```
-Access http://localhost:8090 to access the WebUI
+Access http://localhost to access the WebUI
 
 *Notes for Mac users:
 Port mappings may not bridge to the host on macOS Docker Desktop (Docker runs inside a Linux VM there), making `localhost` unreachable. Fix this by adding explicit port mappings to docker run flags, [cmd 250 of manage.py](https://github.com/Agroecology-Lab/feldfreund_devkit_ros/blob/8dcfde1b813bd829756a372d88195bb2b9249313/manage.py#L250) 

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ The primary entry point for the system. While it runs the full stack by default,
 | `./manage.py build +pull` | `build` | Re-clones the 9 external repos, keeps apt/pip/local layers cached |
 | `./manage.py build +pull +sim` | `build ` | Same, plus INSTALL_SIM=true |
 | `./manage.py full-build` | `full-build` | Runs `run_build(full=True)`. Cleans system & Re-installs all system dependencies. |
-| `./manage.py neo` | `neo` | Runs `neo`. Runs only the line following code for the second 'neo'(cortex) perception SBC. Then check `http://localhost:8081` |
-| `./manage.py neo-tsm` | `neo-tsm` | Runs `neo-tsm`. Runs experimental line following informed by [Vision based Crop Row Navigation under Varying Field Conditions in Arable Fields - Rajitha de Silva1, Grzegorz Cielniak2 and Junfeng Gao](https://arxiv.org/pdf/2209.14003). Then check `http://localhost:8081` |
+| `./manage.py neo` | `neo` | Runs `neo`. Runs only the line following code for the second 'neo'(cortex) perception SBC. Then check `http://localhost:8080` |
+| `./manage.py neo-tsm` | `neo-tsm` | Runs `neo-tsm`. Runs experimental line following informed by [Vision based Crop Row Navigation under Varying Field Conditions in Arable Fields - Rajitha de Silva1, Grzegorz Cielniak2 and Junfeng Gao](https://arxiv.org/pdf/2209.14003). Then check `http://localhost:8080` |
 | `./manage.py pull-caatinga` | `pulls & builds vision pipeline` | Requires the container to already be running |
 
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Use the management script to build the ROS 2 workspace and launch the robot stac
 xhost +local:docker
 ./manage.py 
 ```
-Access http://localhost to access the WebUI
+Access http://localhost:8090 to access the WebUI
 
 *Notes for Mac users:
 Port mappings may not bridge to the host on macOS Docker Desktop (Docker runs inside a Linux VM there), making `localhost` unreachable. Fix this by adding explicit port mappings to docker run flags, [cmd 250 of manage.py](https://github.com/Agroecology-Lab/feldfreund_devkit_ros/blob/8dcfde1b813bd829756a372d88195bb2b9249313/manage.py#L250) 
@@ -156,12 +156,64 @@ The primary entry point for the system. While it runs the full stack by default,
 | `./manage.py build +pull` | `build` | Re-clones the 9 external repos, keeps apt/pip/local layers cached |
 | `./manage.py build +pull +sim` | `build ` | Same, plus INSTALL_SIM=true |
 | `./manage.py full-build` | `full-build` | Runs `run_build(full=True)`. Cleans system & Re-installs all system dependencies. |
-| `./manage.py neo` | `neo` | Runs `neo`. Runs only the line following code for the second 'neo'(cortex) perception SBC. Then check `http://localhost:8080` |
-| `./manage.py neo-tsm` | `neo-tsm` | Runs `neo-tsm`. Runs experimental line following informed by [Vision based Crop Row Navigation under Varying Field Conditions in Arable Fields - Rajitha de Silva1, Grzegorz Cielniak2 and Junfeng Gao](https://arxiv.org/pdf/2209.14003). Then check `http://localhost:8080` |
+| `./manage.py neo` | `neo` | Runs `neo`. Runs only the line following code for the second 'neo'(cortex) perception SBC. Then check `http://localhost:8081` |
+| `./manage.py neo-tsm` | `neo-tsm` | Runs `neo-tsm`. Runs experimental line following informed by [Vision based Crop Row Navigation under Varying Field Conditions in Arable Fields - Rajitha de Silva1, Grzegorz Cielniak2 and Junfeng Gao](https://arxiv.org/pdf/2209.14003). Then check `http://localhost:8081` |
 | `./manage.py pull-caatinga` | `pulls & builds vision pipeline` | Requires the container to already be running |
 
 
 
+
+### One-command sim launch (TMuLE)
+
+[TMuLE](https://github.com/marc-hanheide/TMuLE) brings the whole row-following sim up in a single `tmux` session — one window per process — instead of running the three launch steps by hand in separate terminals:
+
+```bash
+tmule -c tmule/row_follow_sim.yaml launch
+tmux attach -t row_follow_sim
+```
+
+That starts `./manage.py --sim` (nav stack + Nav2 + UI), Gazebo (`sowbot_sim.launch.py`) and the crop-row CV node (`crop_row_nav.launch.py`), each in its own tmux window. `launch` returns immediately and leaves the session detached, so attach to watch the panes come up (and to type the `nav_stack` sudo password).
+
+One-time install (`tmux` plus the tool itself):
+
+```bash
+sudo apt install -y tmux pipx
+pipx install tmule && pipx ensurepath   # then open a new shell
+```
+
+Stop the stack with `tmule -c tmule/row_follow_sim.yaml stop`; re-attach later with `tmux attach -t row_follow_sim`.
+
+> If a runtime container is **already running**, the `nav_stack` window will fail on a `docker run` name collision. Either `docker stop sowbot_runtime` first, or launch just the windows that reuse the container: `tmule -c tmule/row_follow_sim.yaml launch -w gazebo`.
+
+#### tmux basics
+
+The stack runs in a *detached* tmux session named `row_follow_sim`, so closing your terminal does not kill it — **detaching is not stopping**. The session holds one window per sub-system (plus a stray `0: bash` that tmux always creates):
+
+```
+0: bash   1: nav_stack   2: gazebo   3: crop_row
+```
+
+Every shortcut starts with the prefix `Ctrl-b` — press and release it, then the next key:
+
+| Keys | Resulting Action |
+|:---|:---|
+| `Ctrl-b` `d` | Detach — leaves the whole stack running in the background |
+| `Ctrl-b` `w` | Interactive window picker (easiest way to move around) |
+| `Ctrl-b` `1` / `2` / `3` | Jump straight to `nav_stack` / `gazebo` / `crop_row` |
+| `Ctrl-b` `n` / `p` | Next / previous window |
+| `Ctrl-b` `[` | Scroll back through ROS log output — arrows/PgUp, `q` to exit |
+| `Ctrl-b` `z` | Zoom the current pane fullscreen (press again to unzoom) |
+| `Ctrl-b` `?` | List every binding |
+
+```bash
+tmux ls                              # list sessions
+tmux attach -t row_follow_sim        # attach
+tmux kill-session -t row_follow_sim  # nuke the session
+```
+
+Scrolling back (`Ctrl-b` `[`) is the one you'll reach for most — it's how you read ROS output that has already scrolled past. For mouse-wheel scrolling instead, add `set -g mouse on` to `~/.tmux.conf`.
+
+Scenario configs live in [`tmule/`](tmule/) — see [`tmule/README.md`](tmule/README.md) to tweak launch arguments or add your own scenario.
 
 ### Interactive Shell
 To enter the running container for debugging or manual ROS 2 commands:

--- a/tmule/README.md
+++ b/tmule/README.md
@@ -1,0 +1,120 @@
+# TMuLE sim launchers
+
+[TMuLE](https://github.com/marc-hanheide/TMuLE) (the TMux Launch Engine) brings up
+a whole multi-process system in a single `tmux` session from one YAML file — one
+window per sub-system, one pane per command. These configs replace the manual
+copy-paste in `~/.scripts/sowbot_launch.script`.
+
+## Scenarios
+
+| Scenario | File | What it starts |
+| --- | --- | --- |
+| `row_follow_sim` | [`row_follow_sim.yaml`](row_follow_sim.yaml) | Nav stack (`./manage.py --sim`) + Gazebo (`sowbot_sim.launch.py`) + crop-row CV node (`crop_row_nav.launch.py`) |
+
+All three windows share one Docker container (`sowbot_runtime`). `nav_stack`
+creates it; `gazebo` and `crop_row` `docker exec` into it and self-gate until the
+container — and the generated world — are ready (helpers in [`lib.sh`](lib.sh)).
+
+## Install (once)
+
+`tmule` needs `tmux`. On Ubuntu 24.04 (PEP-668, "externally managed" Python), the
+cleanest install is via `pipx`:
+
+```bash
+sudo apt install -y tmux pipx
+pipx install tmule
+pipx ensurepath          # then open a new shell so `tmule` is on PATH
+```
+
+Alternatively, in a virtualenv:
+
+```bash
+sudo apt install -y tmux
+python3 -m venv ~/.venvs/tmule && ~/.venvs/tmule/bin/pip install tmule
+# add ~/.venvs/tmule/bin to PATH, or call ~/.venvs/tmule/bin/tmule directly
+```
+
+## Usage
+
+From the repo root:
+
+```bash
+# Launch the full row-following sim
+tmule -c tmule/row_follow_sim.yaml launch
+
+# Watch it / interact with the panes
+tmux attach -t row_follow_sim      # Ctrl-b w = switch window, Ctrl-b d = detach
+
+# Shut it all down (Ctrl-C each pane; manage.py stops the container)
+tmule -c tmule/row_follow_sim.yaml stop
+
+# Nuke the session entirely
+tmule -c tmule/row_follow_sim.yaml terminate
+```
+
+`launch` returns as soon as the panes are started and leaves the tmux session
+detached, so attach separately to watch it (and to type the `nav_stack` sudo
+password).
+
+### Notes
+
+- **Sudo prompt:** the `nav_stack` pane runs `./manage.py --sim`, which may run
+  `sudo python3 fixusb.py`. Attach and type the password in that pane (or set up
+  passwordless sudo). Until the container is up, the `gazebo`/`crop_row` panes
+  just wait.
+- **Timeouts:** the waits are generous (10 min) to cover the sudo prompt and
+  first-run world generation. Override with `FF_WAIT_CONTAINER_TIMEOUT` /
+  `FF_WAIT_WORLD_TIMEOUT` (seconds) in the environment.
+- **Restart just one part:** `tmule -c tmule/row_follow_sim.yaml relaunch -w gazebo`
+  (or `stop`/`launch` with `-w <window>`).
+
+## tmux cheat sheet
+
+TMuLE is just a driver for `tmux` — once launched, everything lives in one
+detached tmux session named after the scenario (`row_follow_sim`). You don't need
+tmux running in the foreground: detach and the stack keeps going.
+
+The session has one window per sub-system, plus a stray `0: bash` window that
+tmux creates with every new session (harmless — ignore it):
+
+```
+0: bash   1: nav_stack   2: gazebo   3: crop_row
+```
+
+### From the shell
+
+```bash
+tmux ls                                # list sessions
+tmux attach -t row_follow_sim          # attach
+tmux kill-session -t row_follow_sim    # nuke the session (tmule terminate does this too)
+```
+
+### Inside the session
+
+Every shortcut starts with the **prefix**, `Ctrl-b` — press and release it, then
+the next key.
+
+| Keys | Does |
+| --- | --- |
+| `Ctrl-b` `d` | **Detach** — leaves everything running in the background |
+| `Ctrl-b` `w` | Interactive window picker (easiest way to move around) |
+| `Ctrl-b` `1` / `2` / `3` | Jump straight to `nav_stack` / `gazebo` / `crop_row` |
+| `Ctrl-b` `n` / `p` | Next / previous window |
+| `Ctrl-b` `[` | **Scroll back** through output — arrows/PgUp/PgDn, `q` to exit |
+| `Ctrl-b` `z` | Zoom the current pane fullscreen (press again to unzoom) |
+| `Ctrl-b` `?` | List every binding |
+
+Scrolling back (`Ctrl-b` `[`) is the one you'll use most — it's how you read ROS
+log output that has already scrolled past. To scroll with the mouse wheel
+instead, add `set -g mouse on` to `~/.tmux.conf`.
+
+`Ctrl-c` in a pane stops just that process, which is what `tmule stop` sends.
+Note that detaching is **not** stopping: use
+`tmule -c tmule/<scenario>.yaml stop` to shut the stack down.
+
+## Adding a scenario
+
+Copy `row_follow_sim.yaml` to `tmule/<name>.yaml`, set `session: <name>`, and
+edit the windows. `tmule -c tmule/<name>.yaml launch` and `tmux attach -t <name>`
+then just work.
+Shared shell helpers live in `lib.sh`; keep `init_cmd` sourcing it.

--- a/tmule/lib.sh
+++ b/tmule/lib.sh
@@ -1,0 +1,76 @@
+# Shared shell helpers for the TMuLE sim configs.
+#
+# Sourced by each config's `init_cmd`, so every pane (and every `check`) gets
+# these functions. The whole sim stack runs against ONE Docker container
+# started by `./manage.py --sim`; the gazebo/crop panes just `docker exec` into
+# it, so they must wait for it (and for the generated world) to be ready.
+#
+# Timeouts are generous on purpose: the nav_stack pane may sit on a `sudo`
+# password prompt (fixusb.py) and a first-ever run also generates the world.
+# Override via env if needed, e.g. FF_WAIT_CONTAINER_TIMEOUT=120.
+
+# Name of the running runtime container. Mirrors the detection in login.sh so
+# this keeps working across the project's historical container names.
+ff_container() {
+    docker ps --format '{{.Names}}' \
+        | grep -E '^(sowbot_runtime|feldfreund_runtime|feldfreund_dev|open_ag_runtime|open_agbot)$' \
+        | head -n1
+}
+
+# Block until the runtime container exists. Returns non-zero on timeout.
+ff_wait_container() {
+    cn=""
+    i=0
+    timeout="${FF_WAIT_CONTAINER_TIMEOUT:-600}"
+    echo "[tmule] waiting up to ${timeout}s for the runtime container"
+    echo "[tmule]   (nav_stack pane runs ./manage.py --sim — it may ask for a sudo password)"
+    while [ "$i" -lt "$timeout" ]; do
+        cn="$(ff_container)"
+        if [ -n "$cn" ]; then
+            echo "[tmule] runtime container is up: $cn"
+            return 0
+        fi
+        i=$((i + 1))
+        [ $((i % 30)) -eq 0 ] && echo "[tmule] ...still waiting for the container (${i}s)"
+        sleep 1
+    done
+    echo "[tmule] ERROR: runtime container did not appear within ${timeout}s" >&2
+    return 1
+}
+
+# Block until the topo-derived Gazebo world has been generated inside the
+# container. Warns and returns 0 (does NOT block launch) if it never shows up,
+# so Gazebo still gets a chance to start.
+ff_wait_world() {
+    world="/workspace/install/devkit_simulation/share/devkit_simulation/worlds/maize.world"
+    cn="$(ff_container)"
+    [ -z "$cn" ] && return 0
+    i=0
+    timeout="${FF_WAIT_WORLD_TIMEOUT:-600}"
+    echo "[tmule] waiting up to ${timeout}s for the generated world ($world)"
+    while [ "$i" -lt "$timeout" ]; do
+        if docker exec "$cn" test -f "$world" 2>/dev/null; then
+            echo "[tmule] world is ready"
+            return 0
+        fi
+        i=$((i + 2))
+        sleep 2
+    done
+    echo "[tmule] WARN: world not detected after ${timeout}s; launching Gazebo anyway" >&2
+    return 0
+}
+
+# Run a ROS 2 command inside the runtime container with the environment sourced
+# (mirrors login.sh and manage.py's _ros_source). Usage: ff_exec ros2 launch ...
+ff_exec() {
+    cn="$(ff_container)"
+    if [ -z "$cn" ]; then
+        echo "[tmule] ERROR: no runtime container found; is ./manage.py --sim running?" >&2
+        return 1
+    fi
+    docker exec -it "$cn" bash -c "
+        source /opt/ros/*/setup.bash 2>/dev/null
+        [ -f /workspace/install/setup.bash ] && source /workspace/install/setup.bash
+        export PYTHONPATH=\$PYTHONPATH:/workspace/src/devkit_ui
+        exec $*"
+}

--- a/tmule/lib.sh
+++ b/tmule/lib.sh
@@ -68,9 +68,9 @@ ff_exec() {
         echo "[tmule] ERROR: no runtime container found; is ./manage.py --sim running?" >&2
         return 1
     fi
-    docker exec -it "$cn" bash -c "
+    docker exec -it "$cn" bash -lc '
         source /opt/ros/*/setup.bash 2>/dev/null
         [ -f /workspace/install/setup.bash ] && source /workspace/install/setup.bash
-        export PYTHONPATH=\$PYTHONPATH:/workspace/src/devkit_ui
-        exec $*"
+        export PYTHONPATH="$PYTHONPATH:/workspace/src/devkit_ui"
+        exec "$@"' bash "$@"
 }

--- a/tmule/row_follow_sim.yaml
+++ b/tmule/row_follow_sim.yaml
@@ -1,0 +1,50 @@
+# TMuLE launch config: full row-following SIMULATION stack.
+#
+# One tmux window per sub-system, one pane each. This is the automated
+# equivalent of the three manual steps in ~/.scripts/sowbot_launch.script.
+#
+#   Launch:  tmule -c tmule/row_follow_sim.yaml launch
+#   Attach:  tmux attach -t row_follow_sim
+#   Stop:    tmule -c tmule/row_follow_sim.yaml stop
+#
+# All three sub-systems share ONE Docker container (sowbot_runtime):
+#   1. nav_stack  -> ./manage.py --sim  creates the container + runs topo nav / Nav2 / UI
+#   2. gazebo     -> docker exec ... ros2 launch devkit_bringup sowbot_sim.launch.py
+#   3. crop_row   -> docker exec ... ros2 launch sowbot_row_follow crop_row_nav.launch.py
+#
+# nav_stack has no `check`, so `launch` returns immediately and the tmux session
+# runs in the background. The gazebo/crop_row panes self-gate (ff_wait_*) until
+# the container — and the generated world — are ready, so ordering is automatic.
+
+session: row_follow_sim
+
+# Sourced into every pane's shell before its command runs (and prepended to
+# every check). Defines the ff_* helpers from lib.sh and cd's to the repo root
+# so ./manage.py resolves. @TMULE_CONFIG_DIR@ = this file's directory.
+init_cmd: |
+  cd "@TMULE_CONFIG_DIR@/.." || exit 1
+  source "@TMULE_CONFIG_DIR@/lib.sh"
+
+windows:
+  # 1. Nav stack: creates the sowbot_runtime container and runs topo nav +
+  #    Nav2 + UI. May prompt for a sudo password (fixusb.py) — enter it here.
+  - name: nav_stack
+    panes:
+      - ./manage.py --sim
+
+  # 2. Gazebo: waits for the container and the topo-derived world, then launches
+  #    the sim (normally started from the UI System tab; here it's automated).
+  - name: gazebo
+    panes:
+      - |
+        ff_wait_container || exit 1
+        ff_wait_world
+        ff_exec ros2 launch devkit_bringup sowbot_sim.launch.py world:=maize.world urdf:=ifarmate.urdf.xacro
+
+  # 3. Crop-row CV node: not started by either of the above. Waits for the
+  #    container, then runs the detector against the sim camera feed.
+  - name: crop_row
+    panes:
+      - |
+        ff_wait_container || exit 1
+        ff_exec ros2 launch sowbot_row_follow crop_row_nav.launch.py use_camera:=false image_topic:=/camera/image_raw detector:=tsmV


### PR DESCRIPTION
## Motivation

Starting the row-following sim means running three things by hand in three terminals, in order: ./manage.py --sim (creates the runtime container), then Gazebo, then the crop-row CV node — the last two have to docker exec into the container the first one creates. That sequence lived in a personal scratch file and was copy-pasted.

## Implementation

tmule/row_follow_sim.yaml runs all three in one tmux session, one window each. nav_stack has no check (it may sit on a sudo prompt), so launch returns immediately and the other two panes self-gate on helpers in tmule/lib.sh: ff_wait_container (fatal on timeout — nothing to exec into) and ff_wait_world (warns only). Both timeouts are env-overridable. Nothing outside tmule/ changes; the manual three-terminal workflow still works.

`tmule -c tmule/row_follow_sim.yaml launch    # start all three windows (returns immediately)`
`tmux attach -t row_follow_sim                # watch it — type the sudo password in nav_stack`
or just `tmux a`

Detach with Ctrl-b d; the stack keeps running.

To shut down:

`tmule -c tmule/row_follow_sim.yaml stop         # Ctrl-C every pane`
`tmule -c tmule/row_follow_sim.yaml terminate    # kill the session outright`
