### PR TITLE
Pull out topo types

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+deepdiff
 pytest
 pytest-asyncio
 mypy

--- a/src/devkit_ui/devkit_ui/missions/sqlite.py
+++ b/src/devkit_ui/devkit_ui/missions/sqlite.py
@@ -31,6 +31,10 @@ class MissionSqliteStore:
         """Attaches the store to a node."""
         # Nothing needed here.
 
+    def close(self) -> None:
+        """Closes the store."""
+        self._conn.close()
+
     # ── public API ────────────────────────────────────────────────────────
 
     def add(self,

--- a/src/devkit_ui/devkit_ui/missions/test_sqlite.py
+++ b/src/devkit_ui/devkit_ui/missions/test_sqlite.py
@@ -8,6 +8,9 @@ class TestMissionSqliteStore(unittest.TestCase):
     def setUp(self) -> None:
         self._store = MissionSqliteStore(':memory:')
 
+    def tearDown(self) -> None:
+        self._store.close()
+
     def test_missions_getter_returns_all_missions_in_id_order(self) -> None:
         self._store.add(rows=[3], action='spray', action_params={'dose': 3}, name='THIRD')
         self._store.add(rows=[1], action='weed', action_params={'dose': 1}, name='FIRST')

--- a/src/devkit_ui/devkit_ui/models.py
+++ b/src/devkit_ui/devkit_ui/models.py
@@ -90,6 +90,12 @@ class TopoNode:
         verts: list[Vector2] | None = None,
         meta: dict | None = None,
     ) -> None:
+        """Constructs a new topo node.
+
+        For convenience you can pass in an x/y pair instead of a full pose.
+        """
+
+
         if pose is not None:
             if x is not None or y is not None:
                 raise ValueError("cannot pass x and y if pose is provided")
@@ -144,10 +150,16 @@ class TopoNode:
         if isinstance(edge, NodeID):
             edge = TopoEdge(action=action or '', edge_id=f'{self._name}_{edge}', node=edge)
 
+        if edge.node == self._name:
+            return
+
         self._edges[edge.node] = edge
 
     def remove_edge(self, node_id: NodeID) -> None:
         self.remove_edges({node_id})
+
+    def is_connected_to(self, node_id: NodeID) -> bool:
+        return node_id in self._edges
 
     def remove_edges(self, node_ids: set[NodeID]) -> None:
         for node_id in node_ids:
@@ -168,6 +180,10 @@ class TopoNode:
             },
             'meta': self._meta,
         }
+
+    def patch_role(self, role: str) -> None:
+        self._properties['row_role'] = role
+        self._meta['row_role'] = role
 
 class TopoDoc:
     """Represents a topo document."""
@@ -272,6 +288,8 @@ class TopoDoc:
         }
 
     def clone_empty(self, map_name: str | None = None) -> 'TopoDoc':
+        """Clones the document and returns a new document with no nodes.
+        Retains metadata, actions, definitions, and transformation."""
         return TopoDoc(
             name=map_name or self._name,
             metric_map=self._metric_map,

--- a/src/devkit_ui/devkit_ui/models.py
+++ b/src/devkit_ui/devkit_ui/models.py
@@ -1,0 +1,284 @@
+import copy
+from collections.abc import Iterator
+from datetime import datetime
+from typing import NamedTuple
+
+# TODO(robbrit): These position types are probably defined somewhere else and we can use those.
+
+EdgeID = str
+NodeID = str
+
+class Vector4(NamedTuple):
+    """Represents a 4D vector."""
+    x: float
+    y: float
+    z: float = 0.0
+    w: float = 1.0
+
+class Vector3(NamedTuple):
+    """Represents a 3D vector."""
+    x: float
+    y: float
+    z: float = 0.0
+
+class Vector2(NamedTuple):
+    """Represents a 2D vector."""
+    x: float
+    y: float
+
+class TopoPose:
+    """Represents a point's pose in 3D space."""
+    def __init__(self, **kwargs):
+        if 'orientation' not in kwargs:
+            kwargs['orientation'] = Vector4(x=0.0, y=0.0, z=0.0, w=1.0)
+        if 'position' not in kwargs:
+            kwargs['position'] = Vector3(x=kwargs.get('x', 0.0), y=kwargs.get('y', 0.0), z=0.0)
+
+        self._orientation: Vector4 = kwargs['orientation']
+        self._position: Vector3 = kwargs['position']
+
+    def to_dict(self) -> dict:
+        return {
+            'orientation': self._orientation._asdict(),
+            'position': self._position._asdict(),
+        }
+
+    @property
+    def orientation(self) -> Vector4:
+        return self._orientation
+
+    @property
+    def position(self) -> Vector3:
+        return self._position
+
+class TopoProperties(NamedTuple):
+    """Contains a set of properties for a topo node."""
+    xy_goal_tolerance: float = 0.0
+    yaw_goal_tolerance: float = 0.0
+    dropped_by: str = ''
+    timestamp: datetime | None = None
+    row_id: str = ''
+    row_role: str = ''
+    gps_lat: float = 0.0
+    gps_lon: float = 0.0
+    gps_fix_type: int = 0
+    gps_hdop: float | None = None
+
+class TopoEdge(NamedTuple):
+    """Represents an edge between two topo nodes.
+
+    Note that these are not standalone, they are always part of a TopoNode in order to know what
+    the two nodes are that are being connected.
+    """
+    action: str
+    edge_id: EdgeID
+    node: NodeID
+
+class TopoNode:
+    """Represents a topo node."""
+
+    def __init__(
+        self,
+        name: NodeID,
+        pointset: str | None = None,
+        nav_frame: str | None = None,
+        edges: list[TopoEdge | str] | None = None,
+        x: float | None = None,
+        y: float | None = None,
+        pose: TopoPose | None = None,
+        properties: TopoProperties | None = None,
+        verts: list[Vector2] | None = None,
+        meta: dict | None = None,
+    ) -> None:
+        if pose is not None:
+            if x is not None or y is not None:
+                raise ValueError("cannot pass x and y if pose is provided")
+            self._pose = pose
+        else:
+            self._pose = TopoPose(position=Vector3(x=x, y=y))
+
+        self._name: NodeID = name
+        self._pointset: str = pointset or name
+        self._nav_frame: str = nav_frame or name
+        self._edges = {}
+        for edge in edges or []:
+            if isinstance(edge, TopoEdge):
+                self._edges[edge.node] = edge
+            else:
+                self._edges[edge] = TopoEdge(action='', edge_id=f'{self._name}_{edge}', node=edge)
+
+        self._properties: TopoProperties = properties or TopoProperties()
+        self._verts: list[Vector2] = verts or []
+        self._meta: dict = meta or {}
+
+    @property
+    def name(self) -> NodeID:
+        return self._name
+
+    @property
+    def edges(self) -> Iterator[TopoEdge]:
+        return self._edges.values()
+
+    @property
+    def meta(self) -> dict:
+        return self._meta
+
+    @property
+    def x(self) -> float:
+        return self._pose.position.x
+
+    @property
+    def y(self) -> float:
+        return self._pose.position.y
+
+    def ensure_meta(self, map_name: str) -> None:
+        """Ensures that the metadata on the node is valid."""
+        self._meta.setdefault('map', map_name)
+        self._meta.setdefault('node', self._name)
+        self._meta.setdefault('pointset', map_name)
+
+    def add_metadata(self, **kwargs: dict) -> None:
+        self._meta.update(**kwargs)
+
+    def add_edge(self, edge: TopoEdge | NodeID, action: str | None = None) -> None:
+        if isinstance(edge, NodeID):
+            edge = TopoEdge(action=action or '', edge_id=f'{self._name}_{edge}', node=edge)
+
+        self._edges[edge.node] = edge
+
+    def remove_edge(self, node_id: NodeID) -> None:
+        self.remove_edges({node_id})
+
+    def remove_edges(self, node_ids: set[NodeID]) -> None:
+        for node_id in node_ids:
+            if node_id not in self._edges:
+                continue
+            self._edges.pop(node_id)
+
+    def to_dict(self) -> dict:
+        return {
+            'node': {
+                'name': self._name,
+                'pointset': self._pointset,
+                'nav_frame': self._nav_frame,
+                'edges': [edge._asdict() for edge in self._edges.values()],
+                'pose': self._pose.to_dict(),
+                'properties': self._properties._asdict(),
+                'verts': [vert._asdict() for vert in self._verts],
+            },
+            'meta': self._meta,
+        }
+
+class TopoDoc:
+    """Represents a topo document."""
+
+    def __init__(
+        self,
+        name: str,
+        nodes: list[TopoNode] | list[dict] | None = None,
+        metric_map: str | None = None,
+        pointset: str | None = None,
+        meta: dict | None = None,
+        actions: dict | None = None,
+        definitions: dict | None = None,
+        transformation: dict | None = None,
+    ) -> None:
+        self._nodes: dict[NodeID, TopoNode] = {}
+        for node in nodes or []:
+            if isinstance(node, TopoNode):
+                self._nodes[node.name] = node
+            else:
+                topo_node = TopoNode(**node)
+                self._nodes[topo_node.name] = topo_node
+
+        # TODO(rob): Since the nodes here are specified by the caller, it's possible there are edge
+        # inconsistenceies. We should validate the edges here.
+
+        self._name: str = name
+        self._metric_map: str = metric_map or name
+        self._pointset: str = pointset or name
+
+        # TODO(robbrit): Define these ones properly.
+        self._meta: dict = meta or {}
+        self._actions: dict = actions or {}
+        self._definitions: dict = definitions or {}
+        self._transformation: dict = transformation or {}
+
+    def ensure_meta(self, map_name: str | None) -> None:
+        """Ensures that the metadata on the document is valid."""
+        map_name = map_name or self._name
+
+        for node in self._nodes.values():
+            node.ensure_meta(map_name)
+
+    def has_node(self, name: NodeID) -> bool:
+        return name in self._nodes
+
+    def get_node(self, name: NodeID) -> TopoNode:
+        return self._nodes[name]
+
+    @property
+    def nodes(self) -> Iterator[TopoNode]:
+        return self._nodes.values()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def actions(self) -> dict:
+        return self._actions
+
+    @property
+    def definitions(self) -> dict:
+        return self._definitions
+
+    @property
+    def transformation(self) -> dict:
+        return self._transformation
+
+    def add_node(self, node: TopoNode) -> None:
+        self._nodes[node.name] = node
+
+        for edge in node.edges:
+            node_id = edge.node
+
+            self._nodes[node_id].add_edge(TopoEdge(
+                action=edge.action,
+                edge_id=edge.edge_id,
+                node=node.name,
+            ))
+
+    def remove_node(self, name: NodeID) -> None:
+        self.remove_nodes({name})
+
+    def remove_nodes(self, names: set[NodeID]) -> None:
+        for name in names:
+            self._nodes.pop(name)
+
+        for node in self.nodes:
+            node.remove_edges(names)
+
+    def to_dict(self) -> dict:
+        return {
+            'name': self._name,
+            'nodes': [node.to_dict() for node in self._nodes.values()],
+            'metric_map': self._metric_map,
+            'pointset': self._pointset,
+            'meta': self._meta,
+            'actions': self._actions,
+            'definitions': self._definitions,
+            'transformation': self._transformation,
+        }
+
+    def clone_empty(self, map_name: str | None = None) -> 'TopoDoc':
+        return TopoDoc(
+            name=map_name or self._name,
+            metric_map=self._metric_map,
+            pointset=self._pointset,
+            meta=copy.deepcopy(self._meta),
+            actions=copy.deepcopy(self._actions),
+            definitions=copy.deepcopy(self._definitions),
+            transformation=copy.deepcopy(self._transformation),
+            nodes=[],
+        )

--- a/src/devkit_ui/devkit_ui/parse.py
+++ b/src/devkit_ui/devkit_ui/parse.py
@@ -1,0 +1,56 @@
+import json
+from datetime import UTC, datetime
+
+import yaml
+
+from devkit_ui.models import TopoDoc, TopoNode, TopoProperties
+
+
+def _topo_from_dict(doc: dict) -> TopoDoc:
+    nodes = []
+    for entry in doc.get('nodes', []):
+        n = entry.get('node', {})
+        meta = dict(entry.get('meta', {}))
+
+        name = n['name']
+        pos = n['pose']['position']
+        edges = []
+        for e in n.get('edges', []):
+            if isinstance(e, dict) and 'node' in e:
+                edges.append(e['node'])
+            else:
+                edges.append(e)
+        nodes.append(TopoNode(
+            name=name,
+            x=float(pos['x']),
+            y=float(pos['y']),
+            edges=edges,
+            meta=meta,
+            properties=TopoProperties(**n.get('properties', {})),
+            verts=[],
+        ))
+
+    return TopoDoc(
+        nodes=nodes,
+        name=doc.get('name', 'mixed_test_map'),
+        metric_map=doc.get('metric_map', ''),
+        pointset=doc.get('pointset', ''),
+        meta=doc.get('meta', {}),
+        actions=doc.get('actions', {}),
+        definitions=doc.get('definitions', {}),
+        transformation=doc.get('transformation', {}),
+    )
+
+def parse_topo_yaml(filename: str) -> TopoDoc:
+    with open(filename, encoding='utf-8') as f:
+        return _topo_from_dict(yaml.safe_load(f))
+
+def parse_topo_json(json_str: str) -> TopoDoc:
+    return _topo_from_dict(json.loads(json_str))
+
+def dump_topo_yaml(doc: TopoDoc, filename: str) -> None:
+    with open(filename, 'w', encoding='utf-8') as f:
+        data = doc.to_dict()
+        data['meta']['last_updated'] = datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')
+
+        yaml.dump(data, f, default_flow_style=False, allow_unicode=True, sort_keys=True)

--- a/src/devkit_ui/devkit_ui/test_models.py
+++ b/src/devkit_ui/devkit_ui/test_models.py
@@ -1,0 +1,63 @@
+import unittest
+
+from devkit_ui.models import TopoDoc, TopoEdge, TopoNode
+
+
+class TestTopoDoc(unittest.TestCase):
+    def test_init_with_list_of_dict_nodes(self) -> None:
+        doc = TopoDoc(
+            name='test-topo',
+            nodes=[
+                {'name': 'A', 'x': 1.0, 'y': 2.0, 'edges': []},
+                {'name': 'B', 'x': 3.0, 'y': 4.0, 'edges': ['A']},
+            ],
+        )
+
+        self.assertTrue(doc.has_node('A'))
+        self.assertTrue(doc.has_node('B'))
+        self.assertIsInstance(doc.get_node('A'), TopoNode)
+        self.assertEqual([e.node for e in doc.get_node('B').edges], ['A'])
+
+    def test_init_with_list_of_toponodes(self) -> None:
+        node_a = TopoNode(name='A', x=0.0, y=0.0)
+        node_b = TopoNode(name='B', x=1.0, y=1.0, edges=['A'])
+
+        doc = TopoDoc(name='test-topo', nodes=[node_a, node_b])
+
+        self.assertTrue(doc.has_node('A'))
+        self.assertTrue(doc.has_node('B'))
+        self.assertEqual([e.node for e in doc.get_node('B').edges], ['A'])
+
+    def test_add_node_constructs_reverse_edges(self) -> None:
+        doc = TopoDoc(name='test-topo', nodes=[TopoNode(name='A', x=0.0, y=0.0)])
+        node_b = TopoNode(
+            name='B',
+            x=1.0,
+            y=1.0,
+            edges=[TopoEdge(action='move_base', edge_id='B_A', node='A')],
+        )
+
+        doc.add_node(node_b)
+
+        self.assertTrue(doc.has_node('B'))
+        self.assertIn(
+            TopoEdge(action='move_base', edge_id='B_A', node='B'),
+            list(doc.get_node('A').edges),
+        )
+
+    def test_remove_node_removes_related_edges(self) -> None:
+        node_a = TopoNode(name='A', x=0.0, y=0.0, edges=['B'])
+        node_b = TopoNode(name='B', x=1.0, y=1.0, edges=['A', 'C'])
+        node_c = TopoNode(name='C', x=2.0, y=2.0, edges=['B', 'D'])
+        node_d = TopoNode(name='D', x=3.0, y=3.0, edges=['C'])
+        doc = TopoDoc(name='test-topo', nodes=[node_a, node_b, node_c, node_d])
+
+        doc.remove_node('B')
+
+        self.assertFalse(doc.has_node('B'))
+        self.assertEqual(list(doc.get_node('A').edges), [])
+        self.assertEqual([e.node for e in doc.get_node('C').edges], ['D'])
+        self.assertEqual([e.node for e in doc.get_node('D').edges], ['C'])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/devkit_ui/devkit_ui/test_parse.py
+++ b/src/devkit_ui/devkit_ui/test_parse.py
@@ -1,0 +1,42 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from deepdiff import DeepDiff
+
+from devkit_ui.models import TopoDoc, TopoNode
+from devkit_ui.parse import dump_topo_yaml, parse_topo_yaml
+
+
+class TestParseTopo(unittest.TestCase):
+    def test_dump_and_restore_yaml_round_trip(self) -> None:
+        original = TopoDoc(
+            name='test-topo',
+            nodes=[
+                TopoNode(name='A', x=0.0, y=0.0, edges=['B'], meta={'kind': 'start'}),
+                TopoNode(name='B', x=1.0, y=1.0, edges=['A', 'C']),
+                TopoNode(name='C', x=2.0, y=2.0, edges=['B']),
+            ],
+            meta={'map': 'field-1'},
+            actions={'move_base': {}},
+            definitions={'robot': {'type': 'tractor'}},
+            transformation={'frame': 'map'},
+        )
+
+        with TemporaryDirectory() as tmp_dir:
+            yaml_path = Path(tmp_dir) / 'topo.yaml'
+            dump_topo_yaml(original, str(yaml_path))
+            restored = parse_topo_yaml(str(yaml_path))
+
+        original_dict = original.to_dict()
+        restored_dict = restored.to_dict()
+        # `dump_topo_yaml` injects a timestamp on write, so ignore it for equality.
+        original_dict.get('meta', {}).pop('last_updated', None)
+        restored_dict.get('meta', {}).pop('last_updated', None)
+
+        diff = DeepDiff(restored_dict, original_dict)
+        self.assertDictEqual(diff, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/devkit_ui/devkit_ui/ui_node.py
+++ b/src/devkit_ui/devkit_ui/ui_node.py
@@ -938,7 +938,7 @@ class NiceGuiNode(Node):
     # ── node dropping ─────────────────────────────────────────────────────────
 
     def drop_topo_node(self, name: str, row_id: int | None,
-                       row_role: str | None) -> None:
+                       row_role: str = 'entry') -> None:
         name = re.sub(r'[^A-Z0-9_]', '', name.strip().upper().replace(' ', '_'))
         if not name:
             self.drop_status = 'ERROR: node name required'
@@ -964,7 +964,7 @@ class NiceGuiNode(Node):
             connect_to = None
         if not connect_to and self.topo_selected and self._topo_doc.has_node(self.topo_selected):
             connect_to = self.topo_selected
-        map_name  = self._topo_doc.name or 'mixed_test_map'
+        map_name  = self._topo_doc.name
         nav_frame = self._topo_doc.transformation.get('topo_frame_id', 'map')
         is_row    = row_id is not None
 
@@ -976,21 +976,34 @@ class NiceGuiNode(Node):
         gps = self.latest_gps
         gps_meta: dict = {}
         if gps is not None and gps.status.status >= 0:
-            gps_meta = {'gps_lat': round(gps.latitude, 7), 'gps_lon': round(gps.longitude, 7),
-                        'gps_fix_type': int(gps.status.status),
-                        'gps_hdop': None}
+            gps_meta = {
+                'gps_lat': round(gps.latitude, 7),
+                'gps_lon': round(gps.longitude, 7),
+                'gps_fix_type': int(gps.status.status),
+                'gps_hdop': None,
+            }
 
-        row_meta: dict = {'row_id': row_id, 'row_role': row_role or 'entry'} if is_row else {}
-        timestamp = datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')
-        node_meta_disk = {'map': map_name, 'node': name, 'pointset': map_name}
-        node_meta_ui   = {**node_meta_disk, 'dropped_by': 'webui',
-                          'timestamp': timestamp, **gps_meta, **row_meta}
+        row_meta: dict = {}
+        if is_row:
+            row_meta = {
+                'row_id': row_id,
+                'row_role': row_role,
+            }
 
         self._topo_doc.add_node(TopoNode(
             name=name,
             nav_frame=nav_frame,
-            pose=TopoPose(x=x, y=y),
-            meta=node_meta_ui,
+            x=x,
+            y=y,
+            meta={
+                'map': map_name,
+                'node': name,
+                'pointset': map_name,
+                'dropped_by': 'webui',
+                'timestamp': datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S'),
+                **gps_meta,
+                **row_meta
+            },
             properties=TopoProperties(xy_goal_tolerance=xy_tol, yaw_goal_tolerance=yaw_tol),
             verts=[
                 Vector2(x=-vert_r, y=-vert_r),
@@ -1388,11 +1401,13 @@ class NiceGuiNode(Node):
         # consecutive nodes. IN→OUT row-follow edges are untouched.
         def _add_headland_edge(p: str, q: str) -> None:
             """Bidirectional nav_to_pose edge p<->q in both graph structures."""
+
+            edge_name = f'{p}_{q}'
+
             for a, b in ((p, q), (q, p)):
-                e = list(new_topo_nodes[a]['edges'])
-                if b not in e:
-                    e.append(b)
-                    new_topo_nodes[a] = {**new_topo_nodes[a], 'edges': e}
+                a_node = new_topo_nodes[a]
+                a_node.add_edge(TopoEdge(action=_NAV_ACTION, edge_id=edge_name, node=b))
+
             for node in new_topo_nodes.values():
                 if node.name not in (p, q):
                     continue
@@ -1404,22 +1419,15 @@ class NiceGuiNode(Node):
         for a_name, b_name in _headland_neighbour_pairs(all_pts):
             _add_headland_edge(a_name, b_name)
 
-        graph_splice: list = []
         if connect_to:
             first_in = row_names[added[0]][0]
             last_out = row_names[added[-1]][1]
 
             for tgt in (first_in, last_out):
-                c_e = list(new_topo_nodes[connect_to].edges)
-                if tgt not in c_e:
-                    c_e.append(tgt)
-                t_e = list(new_topo_nodes[tgt].edges)
-                if connect_to not in t_e:
-                    t_e.append(connect_to)
-                for node in new_topo_nodes.values():
-                    if node.name == tgt:
-                        node.add_edge(connect_to, action=_NAV_ACTION)
-                graph_splice.append((connect_to, tgt))
+                if tgt not in new_topo_nodes:
+                    continue
+                node = new_topo_nodes[tgt]
+                node.add_edge(connect_to, action=_NAV_ACTION)
 
         skip_str   = f' (skipped {len(skipped)} dup ids)' if skipped else ''
         splice_str = f' · spliced @ {connect_to}' if connect_to else ' · standalone'
@@ -1449,12 +1457,6 @@ class NiceGuiNode(Node):
                 if entry.name in existing:
                     continue
                 file_doc.nodes.append(entry)
-            for src, tgt in graph_splice:
-                for entry in file_doc.nodes:
-                    if entry.name != src:
-                        continue
-                    entry.add_edge(tgt, action=_NAV_ACTION)
-                    break
 
         self._persist_and_reload(
             _modify, 'f2c_save_status',
@@ -1646,10 +1648,6 @@ class NiceGuiNode(Node):
     # ── existing helpers below ───────────────────────────────────────────────
 
     def _patch_node_role(self, node_name: str, role: str) -> None:
-        if self._topo_doc.has_node(node_name):
-            nd = self._topo_doc.get_node(node_name)
-            nd.meta['row_role'] = role
-            nd.properties['row_role'] = role
         map_name = self._topo_doc.name
         map_file = f'/workspace/maps/{map_name}'
         def _write():
@@ -1657,11 +1655,9 @@ class NiceGuiNode(Node):
                 if not os.path.exists(map_file):
                     return
                 doc = parse_topo_yaml(map_file)
-                for entry in doc.nodes:
-                    if entry.name == node_name:
-                        entry.meta['row_role'] = role
-                        entry.properties['row_role'] = role
-                        break
+                if doc.has_node(node_name):
+                    node = doc.get_node(node_name)
+                    node.patch_role(role)
                 dump_topo_yaml(doc, map_file)
             except Exception as e:
                 self.get_logger().error(f'_patch_node_role failed: {e}')
@@ -1920,7 +1916,7 @@ class NiceGuiNode(Node):
             if odom is not None:
                 px, py  = odom.pose.pose.position.x, odom.pose.pose.position.y
                 gps_str = (f'\n{gps.latitude:.5f}\n{gps.longitude:.5f}'
-                           if gps and gps.status.status >= 0 else '')
+                        if gps and gps.status.status >= 0 else '')
                 pose_lbl.set_text(f'({px:.2f}, {py:.2f}){gps_str}')
             else:
                 pose_lbl.set_text('no odom')
@@ -1956,10 +1952,11 @@ class NiceGuiNode(Node):
 
             rp = self._robot_pose()
             rp_key = None if rp is None else (round(rp[0], 1), round(rp[1], 1),
-                                              round(rp[2], 2))
+                                            round(rp[2], 2))
             snap = {'sel': self.topo_selected, 'cur': self.topo_current,
                     'stat': self.topo_nav_status, 'nav': self.topo_navigating,
-                    'nodes': id(self._topo_doc.nodes), 'robot': rp_key}
+                    'nodes': set(self._topo_doc.nodes), 'robot': rp_key}
+            nonlocal _prev
             changed = {k for k, v in snap.items() if _prev.get(k) != v}
             if not changed:
                 return
@@ -1971,7 +1968,7 @@ class NiceGuiNode(Node):
             if changed & {'sel', 'cur', 'nodes'}:
                 map_html.set_content(
                     _build_svg(self._topo_doc, self.topo_selected,
-                               self.topo_current))
+                            self.topo_current))
                 inject_click_js()
 
             if changed & {'sel', 'nodes'}:
@@ -2003,7 +2000,7 @@ class NiceGuiNode(Node):
                 'color:#cf222e' if 'fail' in self.topo_nav_status else
                 'color:#1a7f37' if self.topo_nav_status == 'arrived' else 'color:#57606a')
             can_go = (bool(self.topo_selected) and not self.topo_navigating
-                      and not self.soft_estop_active)
+                    and not self.soft_estop_active)
             go_btn.set_enabled(can_go)
             stop_btn.set_enabled(self.topo_navigating)
             del_btn.set_enabled(bool(self.topo_selected))
@@ -2426,11 +2423,13 @@ class NiceGuiNode(Node):
                 ).props('color=negative no-caps flat')
 
             # ── available rows refresh ────────────────────────────────────────
-            _avail_prev = [None]
+            _avail_prev: list[set[TopoNode]] = [set()]
             def _refresh_available():
-                if id(self._topo_doc.nodes) == _avail_prev[0]:
+                nonlocal _avail_prev
+                snap = set(self._topo_doc.nodes)
+                if snap != _avail_prev[0]:
                     return
-                _avail_prev[0] = id(self._topo_doc.nodes)
+                _avail_prev[0] = snap
                 rows: dict[int, str] = {}
                 for nd in self._topo_doc.nodes:
                     meta = nd.meta
@@ -2829,11 +2828,6 @@ class NiceGuiNode(Node):
             dump_topo_yaml(on_disk, archive_path)
 
             # Build empty map doc preserving header fields.
-            # CRITICAL: carry forward `definitions` (BT XML bindings) and
-            # `actions` (action-server config for navigate_to_pose /
-            # limbic_row_follow). Without them, _persist_and_reload reloads a
-            # doc with no action config and every edge fails with
-            # "No action config for 'NavigateToPose'".
             empty_doc = self._topo_doc.clone_empty(map_name)
             dump_topo_yaml(empty_doc, map_file)
             self._topo_doc = empty_doc

--- a/src/devkit_ui/devkit_ui/ui_node.py
+++ b/src/devkit_ui/devkit_ui/ui_node.py
@@ -15,16 +15,18 @@ import subprocess
 import sys
 import threading
 import time
+import traceback
 import zipfile
+from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from itertools import pairwise
+from operator import attrgetter
 from pathlib import Path
 
 # The following imports get generated in the Dockerfile, they aren't available to pylint
 # pylint: disable=import-error
 import fields2cover as f2c
 import rclpy
-import yaml
 from ament_index_python.packages import (
     PackageNotFoundError,
     get_package_share_directory,
@@ -61,6 +63,15 @@ from tf2_ros.transform_listener import TransformListener
 # MISSION: store owns missions.yaml, scheduling, and run recording.
 from devkit_ui.actions import ACTIONS, action_ros_msgs
 from devkit_ui.missions import MissionStore
+from devkit_ui.models import (
+    NodeID,
+    TopoDoc,
+    TopoEdge,
+    TopoNode,
+    TopoPose,
+    TopoProperties,
+    Vector2,
+)
 
 # pylint: enable=import-error
 # OBSTACLE: obstacle manager + UI attachment helpers
@@ -70,6 +81,7 @@ from devkit_ui.obstacles import (
     attach_mission_sidebar_controls,
     attach_nav_card,
 )
+from devkit_ui.parse import dump_topo_yaml, parse_topo_json, parse_topo_yaml
 
 _TOPO_SRV_OK = False
 try:
@@ -103,6 +115,11 @@ TMAP_QOS = QoSProfile(
 
 _ROW_ACTION = 'limbic_row_follow'
 _NAV_ACTION = 'navigate_to_pose'
+
+def _topo_to_msg(doc: TopoDoc) -> String:
+    msg = String()
+    msg.data = json.dumps(doc.to_dict(), ensure_ascii=False)
+    return msg
 
 
 def _headland_neighbour_pairs(coords: dict) -> list:
@@ -209,34 +226,18 @@ body, .nicegui-content { background: var(--bg) !important; color: var(--txt); }
 
 # ── map parser ────────────────────────────────────────────────────────────────
 
-def _parse_topo_json(json_str: str) -> tuple[dict[str, dict], dict]:
-    doc = json.loads(json_str)
-    nodes: dict[str, dict] = {}
-    for entry in doc.get('nodes', []):
-        n     = entry['node']
-        name  = n['name']
-        pos   = n['pose']['position']
-        edges = [e['node'] for e in n.get('edges', []) if 'node' in e]
-        meta  = dict(entry.get('meta', {}))
-        props = n.get('properties', {})
-        for key in ('dropped_by', 'timestamp', 'row_id', 'row_role',
-                    'gps_lat', 'gps_lon', 'gps_fix_type', 'gps_hdop'):
-            if key in props and key not in meta:
-                meta[key] = props[key]
-        nodes[name] = {'x': float(pos['x']), 'y': float(pos['y']),
-                       'edges': edges, 'meta': meta}
-    return nodes, doc
-
-
-def _demo_nodes() -> dict[str, dict]:
-    return {
-        'N1': {'x':  0.0, 'y': 0.0, 'edges': ['N2'],       'meta': {}},
-        'N2': {'x':  3.0, 'y': 0.0, 'edges': ['N1', 'N3'], 'meta': {}},
-        'N3': {'x':  6.0, 'y': 0.0, 'edges': ['N2', 'N4'], 'meta': {}},
-        'N4': {'x':  9.0, 'y': 0.0, 'edges': ['N3', 'N5'], 'meta': {}},
-        'N5': {'x': 12.0, 'y': 0.0, 'edges': ['N4', 'N6'], 'meta': {}},
-        'N6': {'x': 15.0, 'y': 0.0, 'edges': ['N5'],       'meta': {}},
-    }
+def _demo_doc() -> TopoDoc:
+    return TopoDoc(
+        name="mixed_test_map",
+        nodes=[
+            TopoNode(name='N1', pose=TopoPose(x=0.0, y=0.0), edges=['N2'], meta={}),
+            TopoNode(name='N2', pose=TopoPose(x=3.0, y=0.0), edges=['N1', 'N3'], meta={}),
+            TopoNode(name='N3', pose=TopoPose(x=6.0, y=0.0), edges=['N2', 'N4'], meta={}),
+            TopoNode(name='N4', pose=TopoPose(x=9.0, y=0.0), edges=['N3', 'N5'], meta={}),
+            TopoNode(name='N5', pose=TopoPose(x=12.0, y=0.0), edges=['N4', 'N6'], meta={}),
+            TopoNode(name='N6', pose=TopoPose(x=15.0, y=0.0), edges=['N5'], meta={}),
+        ],
+    )
 
 
 # ── SVG renderer ──────────────────────────────────────────────────────────────
@@ -246,14 +247,16 @@ _MARGIN, _NODE_R = 56, 17
 _TF_STALENESS_LIMIT = 2.0  # s — map->base_link older than this: don't draw it
 
 
-def _node_transform(nodes: dict):
+def _node_transform(nodes: Iterator[TopoNode]):
     """World->screen transform (tx, ty) + extents (dx, dy) for the node bbox.
 
     Shared by _build_svg and _build_robot_svg so both layers map coordinates
     identically.
     """
-    xs = [n['x'] for n in nodes.values()]
-    ys = [n['y'] for n in nodes.values()]
+    xs, ys = [], []
+    for node in nodes:
+        xs.append(node.x)
+        ys.append(node.y)
     dx = (max(xs) - min(xs)) or 1.0
     dy = (max(ys) - min(ys)) or 1.0
     x_min, y_min = min(xs), min(ys)
@@ -265,7 +268,7 @@ def _node_transform(nodes: dict):
     return tx, ty, dx, dy
 
 
-def _build_robot_svg(nodes: dict, robot: tuple | None) -> str:
+def _build_robot_svg(nodes: Iterator[TopoNode], robot: tuple | None) -> str:
     """Transparent overlay SVG with only the live robot marker (map frame).
 
     Kept separate from _build_svg so robot movement updates this layer alone,
@@ -288,38 +291,43 @@ def _build_robot_svg(nodes: dict, robot: tuple | None) -> str:
             f'stroke="#ffffff" stroke-width="2"/></svg>')
 
 
-def _build_svg(nodes: dict, selected: str | None, current: str | None) -> str:
-    if not nodes:
+def _build_svg(doc: TopoDoc, selected: str | None, current: str | None) -> str:
+    if not doc.nodes:
         return (f'<svg width="100%" viewBox="0 0 {_SVG_W} {_SVG_H}" '
                 f'style="background:#f6f8fa;border-radius:4px;border:1px solid #d0d7de">'
                 f'<text x="{_SVG_W//2}" y="{_SVG_H//2}" text-anchor="middle" '
                 f'fill="#8c959f" font-family="Courier New" font-size="13">No map loaded</text>'
                 f'</svg>')
 
-    tx, ty, _dx, _dy = _node_transform(nodes)
+    tx, ty, _dx, _dy = _node_transform(doc.nodes)
 
     parts: list[str] = [f'<rect width="{_SVG_W}" height="{_SVG_H}" fill="#f6f8fa" rx="4"/>']
 
     drawn: set = set()
-    for name, nd in nodes.items():
-        for tgt in nd['edges']:
-            key = tuple(sorted([name, tgt]))
-            if key in drawn or tgt not in nodes:
+    for nd in doc.nodes:
+        for tgt in nd.edges:
+            tgt_name = tgt.node
+            key = tuple(sorted([nd.name, tgt_name]))
+            if key in drawn or not doc.has_node(tgt_name):
                 continue
             drawn.add(key)
-            is_row_edge = (nd.get('meta', {}).get('row_id') is not None
-                           or nodes[tgt].get('meta', {}).get('row_id') is not None)
+
+            tgt_node = doc.get_node(tgt_name)
+
+            is_row_edge = (nd.meta.get('row_id') is not None
+                           or tgt_node.meta.get('row_id') is not None)
             parts.append(
-                f'<line x1="{tx(nd["x"]):.1f}" y1="{ty(nd["y"]):.1f}" '
-                f'x2="{tx(nodes[tgt]["x"]):.1f}" y2="{ty(nodes[tgt]["y"]):.1f}" '
+                f'<line x1="{tx(nd.x):.1f}" y1="{ty(nd.y):.1f}" '
+                f'x2="{tx(tgt_node.x):.1f}" y2="{ty(tgt_node.y):.1f}" '
                 f'stroke="{"#d8e8fd" if is_row_edge else "#d0d7de"}" '
                 f'stroke-width="{"2" if is_row_edge else "1"}" stroke-linecap="round"/>')
 
-    for name, nd in nodes.items():
-        cx, cy = tx(nd['x']), ty(nd['y'])
+    for nd in doc.nodes:
+        name = nd.name
+        cx, cy = tx(nd.x), ty(nd.y)
         is_cur = name == current
         is_sel = name == selected
-        is_row = nd.get('meta', {}).get('row_id') is not None
+        is_row = nd.meta.get('row_id') is not None
 
         # pylint: disable=multiple-statements
         if is_cur:
@@ -328,7 +336,7 @@ def _build_svg(nodes: dict, selected: str | None, current: str | None) -> str:
             fill, stroke, sw = '#fff8c5', '#9a6700', 2
         elif is_row:
             fill, stroke, sw = '#d8e8fd', '#0969da', 1
-        elif nd.get('meta', {}).get('dropped_by'):
+        elif nd.meta.get('dropped_by'):
             fill, stroke, sw = '#f6f8fa', '#8c959f', 1
         else:
             fill, stroke, sw = '#ffffff', '#d0d7de', 1
@@ -356,7 +364,7 @@ def _build_svg(nodes: dict, selected: str | None, current: str | None) -> str:
                 f'<text x="{cx:.1f}" y="{cy+4:.1f}" text-anchor="middle" fill="#0969da" '
                 f'font-family="Courier New" font-size="8" font-weight="700" '
                 f'style="pointer-events:none">'
-                f'{nd["meta"].get("row_role","?")[0].upper()}{nd["meta"].get("row_id","")}'
+                f'{nd.meta.get("row_role","?")[0].upper()}{nd.meta.get("row_id","")}'
                 f'</text>')
 
         parts.append(
@@ -720,9 +728,8 @@ class NiceGuiNode(Node):
         self.create_subscription(String, '/current_node',
                                  lambda m: setattr(self, 'topo_current', m.data), _SENSOR_QOS)
 
-        self._topo_doc:  dict            = {}
-        self.topo_nodes: dict[str, dict] = _demo_nodes()
-        self.topo_demo:  bool            = True
+        self._topo_doc:  TopoDoc | None = _demo_doc()
+        self._topo_demo: bool           = False
         self.create_subscription(String, '/topological_map_2', self._on_topo_map, TMAP_QOS)
         self._topo_map_pub = self.create_publisher(String, '/topological_map_2', TMAP_QOS)
 
@@ -875,10 +882,8 @@ class NiceGuiNode(Node):
 
     def _on_topo_map(self, msg: String) -> None:
         try:
-            nodes, doc      = _parse_topo_json(msg.data)
-            self.topo_nodes = nodes
-            self._topo_doc  = doc
-            self.topo_demo  = False
+            self._topo_doc = parse_topo_json(msg.data)
+            self._topo_demo  = False
         except Exception as e:
             self.get_logger().warn(f'Failed to parse /topological_map_2: {e}')
 
@@ -941,7 +946,7 @@ class NiceGuiNode(Node):
         if not _NAME_RE.match(name):
             self.drop_status = f'ERROR: invalid name "{name}"'
             return
-        if name in self.topo_nodes:
+        if self._topo_doc.has_node(name):
             self.drop_status = f'ERROR: {name} already exists'
             return
         if self.latest_odom is None and not self._is_sim:
@@ -955,12 +960,12 @@ class NiceGuiNode(Node):
         y = round(self.latest_odom.pose.pose.position.y, 3) if self.latest_odom else 0.0
         connect_to = (self.topo_current
                       if self.topo_current not in ('—', 'none', 'None', '', None) else None)
-        if connect_to and connect_to not in self.topo_nodes:
+        if connect_to and not self._topo_doc.has_node(connect_to):
             connect_to = None
-        if not connect_to and self.topo_selected and self.topo_selected in self.topo_nodes:
+        if not connect_to and self.topo_selected and self._topo_doc.has_node(self.topo_selected):
             connect_to = self.topo_selected
-        map_name  = self._topo_doc.get('name', 'mixed_test_map')
-        nav_frame = self._topo_doc.get('transformation', {}).get('topo_frame_id', 'map')
+        map_name  = self._topo_doc.name or 'mixed_test_map'
+        nav_frame = self._topo_doc.transformation.get('topo_frame_id', 'map')
         is_row    = row_id is not None
 
         if is_row:
@@ -980,42 +985,23 @@ class NiceGuiNode(Node):
         node_meta_disk = {'map': map_name, 'node': name, 'pointset': map_name}
         node_meta_ui   = {**node_meta_disk, 'dropped_by': 'webui',
                           'timestamp': timestamp, **gps_meta, **row_meta}
-        node_properties_disk = {'xy_goal_tolerance': xy_tol, 'yaw_goal_tolerance': yaw_tol,
-                                 'dropped_by': 'webui', 'timestamp': timestamp,
-                                 **gps_meta, **row_meta}
 
-        def _make_node_dict(meta: dict, props: dict) -> dict:
-            return {'meta': meta, 'node': {
-                'edges': ([{'action': edge_action, 'edge_id': f'{name}_{connect_to}',
-                             'node': connect_to}] if connect_to else []),
-                'name': name, 'nav_frame': nav_frame,
-                'pose': {'orientation': {'w': 1.0, 'x': 0.0, 'y': 0.0, 'z': 0.0},
-                         'position':    {'x': x,   'y': y,   'z': 0.0}},
-                'properties': props,
-                'verts': [{'x': -vert_r, 'y': -vert_r}, {'x': vert_r, 'y': -vert_r},
-                           {'x':  vert_r, 'y':  vert_r}, {'x': -vert_r, 'y':  vert_r}],
-            }}
-
-        _make_node_dict(node_meta_ui, {'xy_goal_tolerance': xy_tol,
-                                       'yaw_goal_tolerance': yaw_tol})
-        new_nodes = dict(self.topo_nodes)
-        new_nodes[name] = {'x': x, 'y': y,
-                           'edges': [connect_to] if connect_to else [],
-                           'meta': node_meta_ui}
-        if connect_to:
-            if connect_to in new_nodes:
-                rev = list(new_nodes[connect_to]['edges'])
-                if name not in rev:
-                    rev.append(name)
-                new_nodes[connect_to] = {**new_nodes[connect_to], 'edges': rev}
-            for entry in self._topo_doc.get('nodes', []):
-                n = entry.get('node', {})
-                if n.get('name') == connect_to:
-                    n.setdefault('edges', []).append(
-                        {'action': edge_action, 'edge_id': f'{connect_to}_{name}', 'node': name})
-                    break
-
-        self.topo_nodes = new_nodes
+        self._topo_doc.add_node(TopoNode(
+            name=name,
+            nav_frame=nav_frame,
+            pose=TopoPose(x=x, y=y),
+            meta=node_meta_ui,
+            properties=TopoProperties(xy_goal_tolerance=xy_tol, yaw_goal_tolerance=yaw_tol),
+            verts=[
+                Vector2(x=-vert_r, y=-vert_r),
+                Vector2(x=vert_r, y=-vert_r),
+                Vector2(x=vert_r, y=vert_r),
+                Vector2(x=-vert_r, y=vert_r),
+            ],
+            edges=[
+                TopoEdge(action=edge_action, edge_id=f'{name}_{connect_to}', node=connect_to),
+            ] if connect_to else [],
+        ))
 
         conn_str = f' → {connect_to}' if connect_to else ''
         gps_str  = (f' [{gps_meta["gps_lat"]:.5f},{gps_meta["gps_lon"]:.5f}]'
@@ -1030,42 +1016,20 @@ class NiceGuiNode(Node):
                                  'topological_navigation/config/mixed_actions_map.yaml')
 
                 if os.path.exists(map_file):
-                    with open(map_file, encoding='utf-8') as f:
-                        file_doc = yaml.safe_load(f)
+                    file_doc = parse_topo_yaml(map_file)
                 elif os.path.exists(installed_src):
-                    with open(installed_src, encoding='utf-8') as f:
-                        file_doc = yaml.safe_load(f)
+                    file_doc = parse_topo_yaml(installed_src)
                     self.get_logger().info('Seeding from installed source')
                 else:
-                    file_doc = copy.deepcopy(self._topo_doc)
+                    file_doc = self._topo_doc
                     self.get_logger().warn('No YAML source — JSON fallback')
 
-                existing_names = {e.get('node', {}).get('name')
-                                  for e in file_doc.get('nodes', [])}
+                existing_names = {e.name for e in file_doc.nodes}
                 if name in existing_names:
                     self.get_logger().warn(f'Node {name} already in file — skipping write')
                     return
 
-                _ts = datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')
-                if 'meta' not in file_doc:
-                    file_doc['meta'] = {}
-                file_doc['meta']['last_updated'] = _ts
-                if 'pointset' not in file_doc:
-                    file_doc['pointset'] = map_name
-
-                file_doc.setdefault('nodes', []).append(
-                    _make_node_dict(node_meta_disk, node_properties_disk))
-                if connect_to:
-                    for entry in file_doc.get('nodes', []):
-                        n = entry.get('node', {})
-                        if n.get('name') == connect_to:
-                            n.setdefault('edges', []).append(
-                                {'action': edge_action,
-                                 'edge_id': f'{connect_to}_{name}', 'node': name})
-                            break
-                with open(map_file, 'w', encoding='utf-8') as f:
-                    yaml.dump(file_doc, f, default_flow_style=False,
-                               allow_unicode=True, sort_keys=False)
+                dump_topo_yaml(file_doc, map_file)
 
                 self._topo_doc = file_doc
 
@@ -1091,23 +1055,19 @@ class NiceGuiNode(Node):
                         self.drop_status = (f'{name}{conn_str} at ({x},{y})'
                                             f'{row_str}{gps_str} — live')
                     else:
-                        msg = String()
-                        msg.data = json.dumps(self._topo_doc, ensure_ascii=False)
-                        self._topo_map_pub.publish(msg)
+                        self._topo_map_pub.publish(_topo_to_msg(self._topo_doc))
                         err = sr.message if sr else 'timeout'
                         self.drop_status = f'{name}{conn_str} saved (switch failed: {err})'
                         self.get_logger().warn(f'switch_topological_map failed ({err})')
                 else:
-                    msg = String()
-                    msg.data = json.dumps(self._topo_doc, ensure_ascii=False)
-                    self._topo_map_pub.publish(msg)
+                    self._topo_map_pub.publish(_topo_to_msg(self._topo_doc))
                     self.drop_status = (f'{name}{conn_str} at ({x},{y})'
                                         f'{row_str}{gps_str} — live (no srv)')
                 self.get_logger().info(
                     f'Node dropped: {name} at ({x:.3f},{y:.3f}){conn_str}{row_str}{gps_str}')
             except Exception as e:
                 self.drop_status = f'ERROR: {e}'
-                self.get_logger().error(f'drop_topo_node failed: {e}')
+                self.get_logger().error(f'drop_topo_node failed: {e} ({type(e)}\n{traceback.format_exc()})')
 
         threading.Thread(target=_publish_and_persist, daemon=True).start()
 
@@ -1122,8 +1082,8 @@ class NiceGuiNode(Node):
         if self._track_timer is not None:
             self.track_status = 'ERROR: already running'
             return
-        existing = [n for n in self.topo_nodes
-                    if n.startswith(prefix + '_') and n[len(prefix)+1:].isdigit()]
+        existing = [n.name for n in self._topo_doc.nodes
+                    if n.name.startswith(prefix + '_') and n.name[len(prefix)+1:].isdigit()]
         self._track_counter = (max(int(n[len(prefix)+1:]) for n in existing)
                                if existing else 0)
         self._track_prefix = prefix
@@ -1207,9 +1167,9 @@ class NiceGuiNode(Node):
                 Trigger.Request()).add_done_callback(_cb)
         threading.Thread(target=_work, daemon=True).start()
 
-    def _persist_and_reload(self, modify_fn, status_attr: str,
+    def _persist_and_reload(self, modify_fn: Callable[[TopoDoc], None], status_attr: str,
                              success_msg: str) -> None:
-        map_name = self._topo_doc.get('name', 'mixed_test_map')
+        map_name = self._topo_doc.name
         map_file = f'/workspace/maps/{map_name}'
         installed_src = ('/workspace/install/topological_navigation/share/'
                          'topological_navigation/config/mixed_actions_map.yaml')
@@ -1217,37 +1177,18 @@ class NiceGuiNode(Node):
         def _work():
             try:
                 if os.path.exists(map_file):
-                    with open(map_file, encoding='utf-8') as f:
-                        file_doc = yaml.safe_load(f)
+                    file_doc = parse_topo_yaml(map_file)
                 elif os.path.exists(installed_src):
-                    with open(installed_src, encoding='utf-8') as f:
-                        file_doc = yaml.safe_load(f)
+                    file_doc = parse_topo_yaml(installed_src)
                 else:
                     file_doc = copy.deepcopy(self._topo_doc)
 
-                # Ensure the doc has the two top-level fields the tmap schema
-                # requires: meta.last_updated and pointset.
-                # Older map files (and our own archive/clear output) may omit
-                # them, causing switch_topological_map → validate() to reject.
-                _ts = datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')
-                if 'meta' not in file_doc:
-                    file_doc['meta'] = {}
-                file_doc['meta']['last_updated'] = _ts
-                if 'pointset' not in file_doc:
-                    file_doc['pointset'] = map_name
-
                 # Backfill missing per-node entry meta (hand-written nodes).
-                for _entry in file_doc.get('nodes', []):
-                    if 'meta' not in _entry:
-                        _nm = _entry.get('node', {}).get('name', '')
-                        _entry['meta'] = {
-                            'map': map_name, 'node': _nm, 'pointset': map_name}
+                file_doc.ensure_meta(map_name)
 
                 modify_fn(file_doc)
 
-                with open(map_file, 'w', encoding='utf-8') as f:
-                    yaml.dump(file_doc, f, default_flow_style=False,
-                               allow_unicode=True, sort_keys=False)
+                dump_topo_yaml(file_doc, map_file)
                 self._topo_doc = file_doc
 
                 def _call(client, req, timeout=5.0):
@@ -1268,21 +1209,17 @@ class NiceGuiNode(Node):
                     if sr and sr.success:
                         setattr(self, status_attr, f'{success_msg} — live')
                     else:
-                        msg = String()
-                        msg.data = json.dumps(self._topo_doc, ensure_ascii=False)
-                        self._topo_map_pub.publish(msg)
+                        self._topo_map_pub.publish(_topo_to_msg(self._topo_doc))
                         err = sr.message if sr else 'timeout'
                         setattr(self, status_attr,
                                 f'{success_msg} (switch failed: {err})')
                 else:
-                    msg = String()
-                    msg.data = json.dumps(self._topo_doc, ensure_ascii=False)
-                    self._topo_map_pub.publish(msg)
+                    self._topo_map_pub.publish(_topo_to_msg(self._topo_doc))
                     setattr(self, status_attr, f'{success_msg} — live (no srv)')
                 self.get_logger().info(f'_persist_and_reload: {success_msg}')
             except Exception as e:
                 setattr(self, status_attr, f'ERROR: {e}')
-                self.get_logger().error(f'_persist_and_reload failed: {e}')
+                self.get_logger().error(f'_persist_and_reload failed: {e} ({type(e)}\n{traceback.format_exc()})')
 
         threading.Thread(target=_work, daemon=True).start()
 
@@ -1350,44 +1287,49 @@ class NiceGuiNode(Node):
             anchor_lon = self.latest_gps.longitude
         fix_type   = int(self.latest_gps.status.status)
 
-        map_name  = self._topo_doc.get('name', 'mixed_test_map')
-        nav_frame = self._topo_doc.get('transformation', {}).get('topo_frame_id', 'map')
+        map_name  = self._topo_doc.name or 'mixed_test_map'
+        nav_frame = self._topo_doc.transformation.get('topo_frame_id', 'map')
         timestamp = datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')
 
         connect_to = (self.topo_current
                       if self.topo_current not in ('—', 'none', 'None', '', None)
                       else None)
-        if connect_to and connect_to not in self.topo_nodes:
+        if connect_to and not self._topo_doc.has_node(connect_to):
             connect_to = None
-        if not connect_to and self.topo_selected and self.topo_selected in self.topo_nodes:
+        if not connect_to and self.topo_selected and self._topo_doc.has_node(self.topo_selected):
             connect_to = self.topo_selected
 
-        new_topo_nodes = dict(self.topo_nodes)
-        if overwrite:
-            new_topo_nodes = {k: v for k, v in new_topo_nodes.items()
-                              if not k.startswith(f'{prefix}_R')}
-        new_entries: list = []
-        added: list = []
-        row_names: dict = {}
-        row_coords: dict = {}   # node_name -> (x, y) for headland end-classification
-        skipped: list = []
+        new_topo_nodes: dict[NodeID, TopoNode] = {}
 
-        verts = [{'x': -0.5, 'y': -0.5}, {'x':  0.5, 'y': -0.5},
-                 {'x':  0.5, 'y':  0.5}, {'x': -0.5, 'y':  0.5}]
+        added: list[int] = []
+        row_names: dict[int, tuple[NodeID, NodeID]] = {}
+        row_coords: dict[str, tuple[float, float]] = {}   # node_name -> (x, y) for headland end-classification
+        skipped: list[int] = []
 
-        def _disk_node(name, x, y, role, lat, lon, edges, rid):
-            meta = {'map': map_name, 'node': name, 'pointset': map_name}
-            props = {'xy_goal_tolerance': 0.1, 'yaw_goal_tolerance': 0.05,
-                        'dropped_by': 'webui_f2c', 'timestamp': timestamp,
-                        'gps_lat': round(lat, 7), 'gps_lon': round(lon, 7),
-                        'gps_fix_type': fix_type, 'gps_hdop': None,
-                        'row_id': rid, 'row_role': role}
-            return {'meta': meta, 'node': {
-                'edges': edges, 'name': name, 'nav_frame': nav_frame,
-                'pose': {'orientation': {'w': 1.0, 'x': 0.0, 'y': 0.0, 'z': 0.0},
-                            'position':    {'x': x,   'y': y,   'z': 0.0}},
-                'properties': props, 'verts': verts,
-            }}
+        verts = [Vector2(x=-0.5, y=-0.5), Vector2(x= 0.5, y=-0.5),
+                 Vector2(x= 0.5, y= 0.5), Vector2(x=-0.5, y= 0.5)]
+
+        def _disk_node(name, x, y, role, lat, lon, edges, rid) -> TopoNode:
+            return TopoNode(
+                name=name,
+                nav_frame=nav_frame,
+                edges=edges,
+                pose=TopoPose(x=x, y=y),
+                properties=TopoProperties(
+                    xy_goal_tolerance=0.1,
+                    yaw_goal_tolerance=0.05,
+                    dropped_by='webui_f2c',
+                    timestamp=timestamp,
+                    gps_lat=round(lat, 7),
+                    gps_lon=round(lon, 7),
+                    gps_fix_type=fix_type,
+                    gps_hdop=None,
+                    row_id=rid,
+                    row_role=role,
+                ),
+                verts=verts,
+                meta={'map': map_name, 'node': name}
+            )
 
         for i, swath in enumerate(self._f2c_swaths):
             if len(swath) < 2:
@@ -1407,25 +1349,18 @@ class NiceGuiNode(Node):
                 skipped.append(rid)
                 continue
 
-
-            in_edges = [{'action': _ROW_ACTION,
-                         'edge_id': f'{in_name}_{out_name}', 'node': out_name}]
-            new_entries.append(_disk_node(in_name,  ix, iy, 'entry', in_lat,  in_lon,  in_edges, rid))
-            new_entries.append(_disk_node(out_name, ox, oy, 'exit',  out_lat, out_lon, [], rid))
-
             ui_meta_common = {'dropped_by': 'webui_f2c', 'timestamp': timestamp,
                               'gps_fix_type': fix_type, 'gps_hdop': None,
                               'row_id': rid}
-            new_topo_nodes[in_name] = {
-                'x': ix, 'y': iy, 'edges': [out_name],
-                'meta': {**ui_meta_common, 'row_role': 'entry',
-                         'gps_lat': round(in_lat, 7), 'gps_lon': round(in_lon, 7)},
-            }
-            new_topo_nodes[out_name] = {
-                'x': ox, 'y': oy, 'edges': [],
-                'meta': {**ui_meta_common, 'row_role': 'exit',
-                         'gps_lat': round(out_lat, 7), 'gps_lon': round(out_lon, 7)},
-            }
+
+            in_edges = [TopoEdge(action=_ROW_ACTION, edge_id=f'{in_name}_{out_name}', node=out_name)]
+            in_node = _disk_node(in_name,  ix, iy, 'entry', in_lat,  in_lon,  in_edges, rid)
+            in_node.add_metadata(**ui_meta_common)
+            out_node = _disk_node(out_name, ox, oy, 'exit',  out_lat, out_lon, [], rid)
+            out_node.add_metadata(**ui_meta_common)
+
+            new_topo_nodes[in_name] = in_node
+            new_topo_nodes[out_name] = out_node
             added.append(rid)
             row_names[rid] = (in_name, out_name)
             # Retain endpoint coords so headland edges can be built by physical
@@ -1458,14 +1393,12 @@ class NiceGuiNode(Node):
                 if b not in e:
                     e.append(b)
                     new_topo_nodes[a] = {**new_topo_nodes[a], 'edges': e}
-            for entry in new_entries:
-                n = entry['node']
-                if n['name'] in (p, q):
-                    other = q if n['name'] == p else p
-                    if not any(ed.get('node') == other for ed in n.get('edges', [])):
-                        n['edges'].append({
-                            'action': _NAV_ACTION,
-                            'edge_id': f"{n['name']}_{other}", 'node': other})
+            for node in new_topo_nodes.values():
+                if node.name not in (p, q):
+                    continue
+
+                other = q if node.name == p else p
+                node.add_edge(other, action=_NAV_ACTION)
 
         all_pts = dict(row_coords)   # {name: (x, y)}
         for a_name, b_name in _headland_neighbour_pairs(all_pts):
@@ -1477,26 +1410,17 @@ class NiceGuiNode(Node):
             last_out = row_names[added[-1]][1]
 
             for tgt in (first_in, last_out):
-                c_e = list(new_topo_nodes[connect_to]['edges'])
+                c_e = list(new_topo_nodes[connect_to].edges)
                 if tgt not in c_e:
                     c_e.append(tgt)
-                    new_topo_nodes[connect_to] = {
-                        **new_topo_nodes[connect_to], 'edges': c_e}
-                t_e = list(new_topo_nodes[tgt]['edges'])
+                t_e = list(new_topo_nodes[tgt].edges)
                 if connect_to not in t_e:
                     t_e.append(connect_to)
-                    new_topo_nodes[tgt] = {**new_topo_nodes[tgt], 'edges': t_e}
-                for entry in new_entries:
-                    n = entry['node']
-                    if n['name'] == tgt and not any(
-                            e.get('node') == connect_to for e in n.get('edges', [])):
-                        n['edges'].append({
-                            'action': _NAV_ACTION,
-                            'edge_id': f'{tgt}_{connect_to}', 'node': connect_to,
-                        })
+                for node in new_topo_nodes.values():
+                    if node.name == tgt:
+                        node.add_edge(connect_to, action=_NAV_ACTION)
                 graph_splice.append((connect_to, tgt))
 
-        self.topo_nodes = new_topo_nodes
         skip_str   = f' (skipped {len(skipped)} dup ids)' if skipped else ''
         splice_str = f' · spliced @ {connect_to}' if connect_to else ' · standalone'
         self.f2c_save_status = (
@@ -1505,43 +1429,37 @@ class NiceGuiNode(Node):
         def _modify(file_doc):
             if overwrite:
                 old_names = {
-                    e.get('node', {}).get('name', '')
-                    for e in file_doc.get('nodes', [])
-                    if e.get('node', {}).get('name', '').startswith(f'{prefix}_R')
+                    e.name
+                    for e in file_doc.nodes
+                    if e.name.startswith(f'{prefix}_R')
                 }
                 if old_names:
-                    file_doc['nodes'] = [
-                        e for e in file_doc.get('nodes', [])
-                        if e.get('node', {}).get('name') not in old_names
+                    file_doc.nodes = [
+                        e for e in file_doc.nodes
+                        if e.name not in old_names
                     ]
                     # Prune dangling edges pointing at removed nodes
-                    for entry in file_doc.get('nodes', []):
-                        n = entry.get('node', {})
-                        n['edges'] = [
-                            e for e in n.get('edges', [])
-                            if e.get('node') not in old_names
+                    for entry in file_doc.nodes:
+                        entry.edges = [
+                            e for e in entry.edges
+                            if e.node not in old_names
                         ]
-            existing = {e.get('node', {}).get('name')
-                        for e in file_doc.get('nodes', [])}
-            for entry in new_entries:
-                if entry['node']['name'] in existing:
+            existing = {e.name for e in file_doc.nodes}
+            for entry in new_topo_nodes.values():
+                if entry.name in existing:
                     continue
-                file_doc.setdefault('nodes', []).append(entry)
+                file_doc.nodes.append(entry)
             for src, tgt in graph_splice:
-                for entry in file_doc.get('nodes', []):
-                    n = entry.get('node', {})
-                    if n.get('name') != src:
+                for entry in file_doc.nodes:
+                    if entry.name != src:
                         continue
-                    if not any(e.get('node') == tgt for e in n.get('edges', [])):
-                        n.setdefault('edges', []).append({
-                            'action': _NAV_ACTION,
-                            'edge_id': f'{src}_{tgt}', 'node': tgt,
-                        })
+                    entry.add_edge(tgt, action=_NAV_ACTION)
                     break
 
         self._persist_and_reload(
             _modify, 'f2c_save_status',
-            f'saved {len(added)} rows · {prefix}{splice_str}{skip_str}')
+            f'saved {len(added)} rows · {prefix}{splice_str}{skip_str}',
+        )
 
     # ── Repair row connectivity ──────────────────────────────────────────────
 
@@ -1552,8 +1470,8 @@ class NiceGuiNode(Node):
 
         rows: dict = {}
         coords: dict = {}   # node_name -> (x, y) for same-end classification
-        for nm, nd in self.topo_nodes.items():
-            meta = nd.get('meta', {}) or {}
+        for node in self._topo_doc.nodes:
+            meta = node.meta
             rid = meta.get('row_id')
             role = meta.get('row_role')
             if rid is None or role not in ('entry', 'exit'):
@@ -1562,18 +1480,16 @@ class NiceGuiNode(Node):
                 rid_int = int(rid)
             except (TypeError, ValueError):
                 continue
-            rows.setdefault(rid_int, {})[role] = nm
+            rows.setdefault(rid_int, {})[role] = node.name
             # x/y live at the top level of the lightweight node dict
-            x, y = nd.get('x'), nd.get('y')
-            if x is not None and y is not None:
-                coords[nm] = (float(x), float(y))
+            coords[node.name] = (node.x, node.y)
 
         if not rows:
             self.f2c_save_status = 'ERROR: no row nodes found'
             return
 
         sorted_rids = sorted(rows)
-        if connect_to and connect_to not in self.topo_nodes:
+        if connect_to and not self._topo_doc.has_node(connect_to):
             self.get_logger().warn(
                 f'repair: connect_to={connect_to!r} not in map, ignoring')
             connect_to = None
@@ -1611,18 +1527,16 @@ class NiceGuiNode(Node):
                 wanted_edges.append((connect_to, tgt, _NAV_ACTION))
                 wanted_edges.append((tgt, connect_to, _NAV_ACTION))
 
-        new_topo_nodes = dict(self.topo_nodes)
+        new_topo_nodes = {node.name: node for node in self._topo_doc.nodes}
         added_count = 0
         for src, tgt, _action in wanted_edges:
             if src not in new_topo_nodes or src == tgt:
                 continue
-            cur = list(new_topo_nodes[src].get('edges', []))
+            cur = new_topo_nodes[src].edges
             if tgt in cur:
                 continue
             cur.append(tgt)
-            new_topo_nodes[src] = {**new_topo_nodes[src], 'edges': cur}
             added_count += 1
-        self.topo_nodes = new_topo_nodes
 
         if added_count == 0:
             self.f2c_save_status = (
@@ -1635,61 +1549,43 @@ class NiceGuiNode(Node):
             for src, tgt, action in wanted_edges:
                 if src == tgt:
                     continue
-                for entry in file_doc.get('nodes', []):
-                    n = entry.get('node', {})
-                    if n.get('name') != src:
+                for entry in file_doc.nodes:
+                    if entry.name != src:
                         continue
-                    if any(e.get('node') == tgt for e in n.get('edges', [])):
+                    if any(e.name == tgt for e in entry.edges):
                         break
-                    n.setdefault('edges', []).append({
-                        'action': action,
-                        'edge_id': f'{src}_{tgt}', 'node': tgt,
-                    })
+                    entry.add_edge(tgt, action=action)
                     break
 
         target_str = (f' @ {connect_to}' if connect_to
                       else ' — NO SPLICE, chain still isolated')
         self._persist_and_reload(
             _modify, 'f2c_save_status',
-            f'repair: wired {added_count} edges{target_str}')
+            f'repair: wired {added_count} edges{target_str}',
+        )
 
     # ── Delete topo nodes / rows ─────────────────────────────────────────────
 
     def delete_topo_node(self, name: str) -> None:
-        if not name or name not in self.topo_nodes:
-            self.delete_status = f'ERROR: {name!r} not in map'
-            return
         if not self._topo_doc:
             self.delete_status = 'ERROR: map not loaded'
             return
+        if not name or not self._topo_doc.has_node(name):
+            self.delete_status = f'ERROR: {name!r} not in map'
+            return
 
-        new_nodes = {}
-        for nm, nd in self.topo_nodes.items():
-            if nm == name:
-                continue
-            edges = [e for e in nd.get('edges', []) if e != name]
-            new_nodes[nm] = {**nd, 'edges': edges}
-        self.topo_nodes = new_nodes
         if self.topo_selected == name:
             self.topo_selected = None
         self.delete_status = f'deleting {name}…'
 
         def _modify(file_doc):
-            kept = []
-            for entry in file_doc.get('nodes', []):
-                n = entry.get('node', {})
-                if n.get('name') == name:
-                    continue
-                n['edges'] = [e for e in n.get('edges', [])
-                              if e.get('node') != name]
-                kept.append(entry)
-            file_doc['nodes'] = kept
+            file_doc.remove_node(name)
 
         self._persist_and_reload(_modify, 'delete_status', f'deleted {name}')
 
     def delete_row(self, row_id: int) -> None:
-        targets = {nm for nm, nd in self.topo_nodes.items()
-                   if nd.get('meta', {}).get('row_id') == row_id}
+        targets = {node.name for node in self._topo_doc.nodes
+                   if node.meta.get('row_id') == row_id}
         if not targets:
             self.delete_status = f'ERROR: no nodes for row {row_id}'
             return
@@ -1697,27 +1593,12 @@ class NiceGuiNode(Node):
             self.delete_status = 'ERROR: map not loaded'
             return
 
-        new_nodes = {}
-        for nm, nd in self.topo_nodes.items():
-            if nm in targets:
-                continue
-            edges = [e for e in nd.get('edges', []) if e not in targets]
-            new_nodes[nm] = {**nd, 'edges': edges}
-        self.topo_nodes = new_nodes
         if self.topo_selected in targets:
             self.topo_selected = None
         self.delete_status = f'deleting row {row_id} ({len(targets)} nodes)…'
 
         def _modify(file_doc):
-            kept = []
-            for entry in file_doc.get('nodes', []):
-                n = entry.get('node', {})
-                if n.get('name') in targets:
-                    continue
-                n['edges'] = [e for e in n.get('edges', [])
-                              if e.get('node') not in targets]
-                kept.append(entry)
-            file_doc['nodes'] = kept
+            file_doc.remove_nodes(targets)
 
         self._persist_and_reload(_modify, 'delete_status',
                                   f'deleted row {row_id} ({len(targets)} nodes)')
@@ -1725,10 +1606,10 @@ class NiceGuiNode(Node):
     # ── Confirmation dialogs ─────────────────────────────────────────────────
 
     async def confirm_delete_node(self, name: str | None) -> None:
-        if not name or name not in self.topo_nodes:
+        if not name or not self._topo_doc.has_node(name):
             return
-        nd = self.topo_nodes[name]
-        rid = nd.get('meta', {}).get('row_id')
+        nd = self._topo_doc.get_node(name)
+        rid = nd.meta.get('row_id')
         with ui.dialog() as d, ui.card():
             ui.label(f'Delete topo node "{name}"?').classes('font-semibold')
             if rid is not None:
@@ -1746,8 +1627,8 @@ class NiceGuiNode(Node):
             self.delete_topo_node(name)
 
     async def confirm_delete_row(self, row_id: int) -> None:
-        targets = sorted(nm for nm, nd in self.topo_nodes.items()
-                         if nd.get('meta', {}).get('row_id') == row_id)
+        targets = sorted(node.name for node in self._topo_doc.nodes
+                         if node.meta.get('row_id') == row_id)
         if not targets:
             return
         with ui.dialog() as d, ui.card():
@@ -1765,35 +1646,23 @@ class NiceGuiNode(Node):
     # ── existing helpers below ───────────────────────────────────────────────
 
     def _patch_node_role(self, node_name: str, role: str) -> None:
-        if node_name in self.topo_nodes:
-            nd = dict(self.topo_nodes[node_name])
-            nd['meta'] = {**nd.get('meta', {}), 'row_role': role}
-            new_nodes = dict(self.topo_nodes)
-            new_nodes[node_name] = nd
-            self.topo_nodes = new_nodes
-        for entry in self._topo_doc.get('nodes', []):
-            n = entry.get('node', {})
-            if n.get('name') == node_name:
-                entry.get('meta', {})['row_role'] = role
-                n.get('properties', {})['row_role'] = role
-                break
-        map_name = self._topo_doc.get('name', 'mixed_test_map')
+        if self._topo_doc.has_node(node_name):
+            nd = self._topo_doc.get_node(node_name)
+            nd.meta['row_role'] = role
+            nd.properties['row_role'] = role
+        map_name = self._topo_doc.name
         map_file = f'/workspace/maps/{map_name}'
         def _write():
             try:
                 if not os.path.exists(map_file):
                     return
-                with open(map_file, encoding='utf-8') as f:
-                    doc = yaml.safe_load(f)
-                for entry in doc.get('nodes', []):
-                    n = entry.get('node', {})
-                    if n.get('name') == node_name:
-                        entry.get('meta', {})['row_role'] = role
-                        n.get('properties', {})['row_role'] = role
+                doc = parse_topo_yaml(map_file)
+                for entry in doc.nodes:
+                    if entry.name == node_name:
+                        entry.meta['row_role'] = role
+                        entry.properties['row_role'] = role
                         break
-                with open(map_file, 'w', encoding='utf-8') as f:
-                    yaml.dump(doc, f, default_flow_style=False,
-                               allow_unicode=True, sort_keys=False)
+                dump_topo_yaml(doc, map_file)
             except Exception as e:
                 self.get_logger().error(f'_patch_node_role failed: {e}')
         threading.Thread(target=_write, daemon=True).start()
@@ -1862,10 +1731,10 @@ class NiceGuiNode(Node):
                         # the clickable node DOM.
                         with ui.element('div').classes('relative w-full'):
                             map_html = ui.html(
-                                _build_svg(self.topo_nodes, None, None)
+                                _build_svg(self._topo_doc, None, None)
                             ).classes('w-full')
                             robot_html = ui.html(
-                                _build_robot_svg(self.topo_nodes, None)
+                                _build_robot_svg(self._topo_doc.nodes, None)
                             ).classes('absolute top-0 left-0 w-full').style(
                                 'pointer-events:none')
 
@@ -2023,7 +1892,7 @@ class NiceGuiNode(Node):
 
         def on_node_clicked(e) -> None:
             n = (e.args or {}).get('node')
-            if n and n in self.topo_nodes:
+            if n and self._topo_doc.has_node(n):
                 self.topo_selected = n
         ui.on('topo_node_clicked', on_node_clicked)
 
@@ -2090,40 +1959,40 @@ class NiceGuiNode(Node):
                                               round(rp[2], 2))
             snap = {'sel': self.topo_selected, 'cur': self.topo_current,
                     'stat': self.topo_nav_status, 'nav': self.topo_navigating,
-                    'nodes': id(self.topo_nodes), 'robot': rp_key}
+                    'nodes': id(self._topo_doc.nodes), 'robot': rp_key}
             changed = {k for k, v in snap.items() if _prev.get(k) != v}
             if not changed:
                 return
             _prev.update(snap)
 
             if changed & {'robot', 'nodes'}:
-                robot_html.set_content(_build_robot_svg(self.topo_nodes, rp))
+                robot_html.set_content(_build_robot_svg(self._topo_doc.nodes, rp))
 
             if changed & {'sel', 'cur', 'nodes'}:
                 map_html.set_content(
-                    _build_svg(self.topo_nodes, self.topo_selected,
+                    _build_svg(self._topo_doc, self.topo_selected,
                                self.topo_current))
                 inject_click_js()
 
             if changed & {'sel', 'nodes'}:
                 node_col.clear()
                 with node_col:
-                    for nname in sorted(self.topo_nodes):
-                        nd       = self.topo_nodes[nname]
-                        is_row   = nd.get('meta', {}).get('row_id') is not None
-                        rid_v    = nd.get('meta', {}).get('row_id', '')
-                        rrole_v  = nd.get('meta', {}).get('row_role', '')
-                        glat     = nd.get('meta', {}).get('gps_lat', '')
-                        glon     = nd.get('meta', {}).get('gps_lon', '')
+                    node_names = sorted(self._topo_doc.nodes, key=attrgetter('name'))
+                    for nd in node_names:
+                        is_row   = nd.meta.get('row_id') is not None
+                        rid_v    = nd.meta.get('row_id', '')
+                        rrole_v  = nd.meta.get('row_role', '')
+                        glat     = nd.meta.get('gps_lat', '')
+                        glon     = nd.meta.get('gps_lon', '')
                         title    = (f'Row {rid_v} {rrole_v} | {glat} {glon}'.strip()
                                     if is_row else f'{glat} {glon}'.strip())
                         cls      = ('node-item'
-                                    + (' sel' if nname == self.topo_selected else '')
+                                    + (' sel' if nd.name == self.topo_selected else '')
                                     + (' row' if is_row else ''))
-                        n = nname
+                        n = nd.name
                         ui.html(
                             f'<div class="{cls}" title="{title}">'
-                            f'{nname}{"  · row" if is_row else ""}</div>'
+                            f'{nd.name}{"  · row" if is_row else ""}</div>'
                         ).on('click', lambda _, n=n: setattr(self, 'topo_selected', n))
 
             cur_lbl.set_text(self.topo_current or '—')
@@ -2375,15 +2244,15 @@ class NiceGuiNode(Node):
         async def do_repair():
             cur = self.topo_current
             default_base = ''
-            if cur not in ('—', 'none', 'None', '', None) and cur in self.topo_nodes:
+            if cur not in ('—', 'none', 'None', '', None) and self._topo_doc.has_node(cur):
                 default_base = cur
-            elif self.topo_selected and self.topo_selected in self.topo_nodes:
+            elif self.topo_selected and self._topo_doc.has_node(self.topo_selected):
                 default_base = self.topo_selected
 
             row_count = sum(
-                1 for nd in self.topo_nodes.values()
-                if nd.get('meta', {}).get('row_id') is not None
-                and nd.get('meta', {}).get('row_role') == 'entry'
+                1 for nd in self._topo_doc.nodes
+                if nd.meta.get('row_id') is not None
+                and nd.meta.get('row_role') == 'entry'
             )
 
             with ui.dialog() as d, ui.card():
@@ -2415,7 +2284,7 @@ class NiceGuiNode(Node):
                 return
 
             base = (base_input.value or '').strip()
-            if base and base not in self.topo_nodes:
+            if base and not self._topo_doc.has_node(base):
                 self.f2c_save_status = f'ERROR: base node {base!r} not in map'
                 return
             self.repair_row_connectivity(connect_to=base or None)
@@ -2559,16 +2428,16 @@ class NiceGuiNode(Node):
             # ── available rows refresh ────────────────────────────────────────
             _avail_prev = [None]
             def _refresh_available():
-                if id(self.topo_nodes) == _avail_prev[0]:
+                if id(self._topo_doc.nodes) == _avail_prev[0]:
                     return
-                _avail_prev[0] = id(self.topo_nodes)
+                _avail_prev[0] = id(self._topo_doc.nodes)
                 rows: dict[int, str] = {}
-                for nname, nd in self.topo_nodes.items():
-                    meta = nd.get('meta', {})
+                for nd in self._topo_doc.nodes:
+                    meta = nd.meta
                     rid  = meta.get('row_id')
                     if rid is not None and meta.get('row_role', '') == 'entry':
                         try:
-                            rows[int(rid)] = nname
+                            rows[int(rid)] = nd.name
                         except (TypeError, ValueError):
                             pass
                 available_col.clear()
@@ -2624,9 +2493,9 @@ class NiceGuiNode(Node):
                         return
                     rows_for_store = [
                         next(
-                            (nname for nname, nd in self.topo_nodes.items()
-                             if nd.get('meta', {}).get('row_id') == rid
-                             and nd.get('meta', {}).get('row_role') == 'entry'),
+                            (nd.name for nd in self._topo_doc.nodes
+                             if nd.meta.get('row_id') == rid
+                             and nd.meta.get('row_role') == 'entry'),
                             f'ROW_{rid}_IN',
                         )
                         for rid, _, _ in mission_queue
@@ -2782,8 +2651,8 @@ class NiceGuiNode(Node):
         # Resolve row_id → (entry_node, exit_node) from current topo map.
         row_entry: dict[int, str] = {}
         row_exit:  dict[int, str] = {}
-        for nname, nd in self.topo_nodes.items():
-            meta = nd.get('meta', {})
+        for nd in self._topo_doc.nodes:
+            meta = nd.meta
             rid  = meta.get('row_id')
             role = meta.get('row_role', '')
             if rid is None:
@@ -2793,9 +2662,9 @@ class NiceGuiNode(Node):
             except (TypeError, ValueError):
                 continue
             if role == 'entry':
-                row_entry[rid_int] = nname
+                row_entry[rid_int] = nd.name
             elif role == 'exit':
-                row_exit[rid_int] = nname
+                row_exit[rid_int] = nd.name
 
         missing_entry = [rid for rid, _, _ in queue if rid not in row_entry]
         missing_exit  = [rid for rid, _, _ in queue if rid not in row_exit]
@@ -2941,7 +2810,7 @@ class NiceGuiNode(Node):
         if not self._topo_doc:
             return 'ERROR: no map loaded'
 
-        map_name = self._topo_doc.get('name', 'mixed_test_map')
+        map_name = self._topo_doc.name
         map_file = f'/workspace/maps/{map_name}'
 
         # Pick next available archive index
@@ -2953,14 +2822,11 @@ class NiceGuiNode(Node):
         try:
             # Read from disk so we archive the persisted state, not just memory
             if os.path.exists(map_file):
-                with open(map_file, encoding='utf-8') as f:
-                    on_disk = yaml.safe_load(f)
+                on_disk = parse_topo_yaml(map_file)
             else:
                 on_disk = copy.deepcopy(self._topo_doc)
 
-            with open(archive_path, 'w', encoding='utf-8') as f:
-                yaml.dump(on_disk, f, default_flow_style=False,
-                           allow_unicode=True, sort_keys=False)
+            dump_topo_yaml(on_disk, archive_path)
 
             # Build empty map doc preserving header fields.
             # CRITICAL: carry forward `definitions` (BT XML bindings) and
@@ -2968,31 +2834,13 @@ class NiceGuiNode(Node):
             # limbic_row_follow). Without them, _persist_and_reload reloads a
             # doc with no action config and every edge fails with
             # "No action config for 'NavigateToPose'".
-            empty_doc = {
-                'meta':           {'last_updated': datetime.now(UTC).strftime('%d-%m-%Y_%H-%M-%S')},
-                'name':           map_name,
-                'metric_map':     self._topo_doc.get('metric_map', map_name),
-                'pointset':       map_name,
-                'transformation': copy.deepcopy(
-                    self._topo_doc.get('transformation', {})),
-                'definitions':    copy.deepcopy(
-                    self._topo_doc.get('definitions', {})),
-                'actions':        copy.deepcopy(
-                    self._topo_doc.get('actions', {})),
-                'nodes':          [],
-            }
-            with open(map_file, 'w', encoding='utf-8') as f:
-                yaml.dump(empty_doc, f, default_flow_style=False,
-                           allow_unicode=True, sort_keys=False)
-
-            self._topo_doc  = empty_doc
-            self.topo_nodes = {}
+            empty_doc = self._topo_doc.clone_empty(map_name)
+            dump_topo_yaml(empty_doc, map_file)
+            self._topo_doc = empty_doc
 
             # Republish so topo nav stack sees the cleared map immediately
             try:
-                msg = __import__('std_msgs.msg', fromlist=['String']).String()
-                msg.data = json.dumps(empty_doc, ensure_ascii=False)
-                self._topo_map_pub.publish(msg)
+                self._topo_map_pub.publish(_topo_to_msg(empty_doc))
             except Exception:
                 pass
 
@@ -3915,7 +3763,7 @@ class NiceGuiNode(Node):
                 'color:#57606a')
 
             async def _do_archive():
-                map_name = self._topo_doc.get('name', '?') if self._topo_doc else '?'
+                map_name = self._topo_doc.name if self._topo_doc else '?'
                 with ui.dialog() as dlg, ui.card():
                     ui.label('Archive and clear map').classes('font-semibold')
                     ui.label(


### PR DESCRIPTION
Bit of a bigger change here, sorry!

Main change is that instead of using a dict to represent the maps, I switched (mostly) to classes. This should help with type/null safety, and I find it's a bit easier to follow when things are objects instead of dicts.

The simpler types are named tuples, this makes them immutable which can reduce the surface area for bugs.

I ended up merging the `topo_nodes` and `_topo_doc` variables, it seems like one was just a partial view of the other.