### PR TITLE
Pin ruff version and fix CI lint errors

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@ pytest
 pytest-asyncio
 mypy
 pylint
-ruff
+ruff==0.16.6
 pre-commit
 livesync
 types-setuptools

--- a/src/devkit_ui/devkit_ui/dem.py
+++ b/src/devkit_ui/devkit_ui/dem.py
@@ -44,11 +44,11 @@ import logging
 from pathlib import Path
 
 import numpy as np
+from devkit_f2c_planner.f2c_planner import _f2c_latlon_to_xy, _f2c_xy_to_latlon
 from scipy.interpolate import RBFInterpolator
 from shapely.geometry import LineString, Point
 from skimage import measure
 
-from devkit_f2c_planner.f2c_planner import _f2c_latlon_to_xy, _f2c_xy_to_latlon
 from devkit_ui.terrain_mask import traversability_mask_to_latlon_rings
 
 # Candidate RBFInterpolator `smoothing` values tried by _choose_smoothing().

--- a/src/devkit_ui/devkit_ui/terrain_mask.py
+++ b/src/devkit_ui/devkit_ui/terrain_mask.py
@@ -19,9 +19,8 @@ this stays unit-testable without a running node.
 """
 
 import numpy as np
-from skimage import measure
-
 from devkit_f2c_planner.f2c_planner import _f2c_xy_to_latlon
+from skimage import measure
 
 
 def traversability_mask_to_latlon_rings(

--- a/src/devkit_ui/devkit_ui/ui_node.py
+++ b/src/devkit_ui/devkit_ui/ui_node.py
@@ -12,7 +12,6 @@ import re
 import shutil
 import signal
 import subprocess
-import sys
 import threading
 import time
 import traceback
@@ -32,6 +31,16 @@ import rclpy
 from ament_index_python.packages import (
     PackageNotFoundError,
     get_package_share_directory,
+)
+
+# F2C: lat/lon<->XY projection + swath generator, now a standalone package
+# (devkit_f2c_planner) — see its f2c_planner.py docstring for why.
+from devkit_f2c_planner.f2c_planner import (
+    _f2c_latlon_to_xy,
+    _f2c_xy_to_latlon,
+    _run_contour_f2c,
+    _run_f2c,
+    field_centroid_xy,
 )
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry
@@ -63,15 +72,7 @@ from tf2_ros.transform_listener import TransformListener
 # MISSION: store owns missions.yaml, scheduling, and run recording.
 from devkit_ui.actions import ACTIONS, action_ros_msgs
 from devkit_ui.constants import NAV_ACTION, NODE_NAME, ROW_ACTION
-# F2C: lat/lon<->XY projection + swath generator, now a standalone package
-# (devkit_f2c_planner) — see its f2c_planner.py docstring for why.
-from devkit_f2c_planner.f2c_planner import (
-    _f2c_latlon_to_xy,
-    _f2c_xy_to_latlon,
-    _run_contour_f2c,
-    _run_f2c,
-    field_centroid_xy,
-)
+
 # CONTOUR: terrain-aware reference line, from recon-logged elevation data.
 # See dem.py's module docstring for the recon.csv -> elevation_grid ->
 # reference contour pipeline this pulls from.
@@ -320,7 +321,7 @@ def _plan_contour_rows(corners_ll: list, obstacle_rings: list, tool_width: float
     rather than silently falling back, since a missing/too-short recon log
     is a setup mistake worth fixing, not a legitimate "flat field" case.
     """
-    xy_native, elevation, latlon = load_recon_points(recon_path)
+    _xy_native, elevation, latlon = load_recon_points(recon_path)
     lat0, lon0 = corners_ll[0]
     # Recon points are logged in recon_dem_logger.py's own /odom-anchored
     # frame, unrelated to whatever frame the user's drawn boundary
@@ -1203,7 +1204,7 @@ class NiceGuiNode(Node):
             # Chain entry -> [waypoints] -> exit with row-follow edges. With
             # no waypoints this is exactly the old direct in_name -> out_name
             # edge.
-            for a_name, b_name in pairwise([in_name] + wp_names + [out_name]):
+            for a_name, b_name in pairwise([in_name, *wp_names, out_name]):
                 new_topo_nodes[a_name].add_edge(b_name, action=ROW_ACTION)
 
             added.append(rid)


### PR DESCRIPTION
requirements-dev.txt pinned an unversioned 'ruff', so CI picked up whatever release was newest on each run. A recent release added RUF059, which this codebase never satisfied, breaking CI on any push regardless of the actual diff. Pin to 0.16.6 (current) and fix the 6 errors that version surfaces:

- 3x I001 (import block un-sorted) -- auto-fixed
- F401 unused 'sys' import in ui_node.py
- RUF059 unused unpacked variable 'xy_native' in ui_node.py (prefixed with underscore, per ruff's own suggestion; genuinely unused)
- RUF005 list-concatenation -> unpacking in ui_node.py (behaviourally identical, wp_names is always a plain list)